### PR TITLE
tilt: port local dev workflow to Kind and unify tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+./_output/k3d-data

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-./_output/k3d-data
+./_output

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ network_closure.sh
 # Downloaded Kubernetes binary release
 /kubernetes/
 
+# k3d cluster data
+/k3d-data
+
 # direnv .envrc files
 .envrc
 

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,12 @@ vendor
 
 # helm dependency files
 installer/helm/chart/volcano/requirements.lock
+
+#### Agentic entries
+# Oh my opencode sisyphus agent work directory
+# https://github.com/code-yeongyu/oh-my-opencode
+.sisyphus/
+.sisyphus/*
+
+# Codex local environment metadata
+.codex/

--- a/.gitignore
+++ b/.gitignore
@@ -105,9 +105,6 @@ network_closure.sh
 # Downloaded Kubernetes binary release
 /kubernetes/
 
-# k3d cluster data
-/k3d-data
-
 # direnv .envrc files
 .envrc
 

--- a/.opencode/skills/tilt-dev.md
+++ b/.opencode/skills/tilt-dev.md
@@ -1,0 +1,134 @@
+# Tilt Dev Loop (Kind volcano-dev)
+
+Use this skill to run and operate Volcano's local Tilt development loop on the
+Kind cluster named `volcano-dev`.
+
+## When to use
+
+- Start or stop local Tilt-driven development.
+- Check resource health quickly.
+- Fetch logs for failing resources.
+- Trigger targeted rebuilds after code changes.
+- Wait for the environment to become ready before tests.
+
+## Ground rules
+
+- Use repository root as the working directory.
+- Prefer project binaries from `_output/bin/` when available.
+- Keep cluster name fixed to `volcano-dev`.
+- Use `hack/tilt/Tiltfile` as the single Tilt entrypoint.
+
+## Canonical workflow
+
+1) Start environment
+
+```bash
+make dev-up
+```
+
+What this does:
+- Ensures `tilt` and `kind` binaries are available in `_output/bin/`.
+- Creates Kind cluster `volcano-dev` if missing.
+- Runs `tilt up -f hack/tilt/Tiltfile`.
+
+2) Quick status snapshot
+
+```bash
+_output/bin/tilt get uiresource
+```
+
+3) Wait for resources to settle
+
+```bash
+make dev-wait-ready
+```
+
+4) Inspect one resource deeply
+
+```bash
+_output/bin/tilt describe uiresource volcano-scheduler
+```
+
+5) Tail logs
+
+All resources:
+
+```bash
+_output/bin/tilt logs
+```
+
+Single resource:
+
+```bash
+_output/bin/tilt logs volcano-scheduler
+```
+
+6) Force rebuild/redeploy for one resource
+
+```bash
+_output/bin/tilt trigger volcano-scheduler
+```
+
+7) Stop environment
+
+```bash
+make dev-down
+```
+
+8) Full cleanup (Tilt down + delete Kind cluster + remove local binaries)
+
+```bash
+make dev-clean
+```
+
+## Troubleshooting playbook
+
+If `make dev-up` fails:
+
+1. Confirm cluster exists:
+
+```bash
+_output/bin/kind get clusters
+```
+
+Expected: `volcano-dev` appears in the list.
+
+2. Confirm context matches Tiltfile expectation:
+
+```bash
+kubectl config get-contexts -o name | grep -E '^(volcano-dev|kind-volcano-dev)$'
+```
+
+3. Verify Tilt can see resources:
+
+```bash
+_output/bin/tilt get uiresource
+```
+
+4. If a resource is stuck/unhealthy, gather details and logs:
+
+```bash
+_output/bin/tilt describe uiresource <resource-name>
+_output/bin/tilt logs <resource-name>
+```
+
+5. Retry only the affected resource:
+
+```bash
+_output/bin/tilt trigger <resource-name>
+```
+
+## CI-style run
+
+Use non-interactive mode when a bounded run is needed:
+
+```bash
+_output/bin/tilt ci -f hack/tilt/Tiltfile
+```
+
+## Notes for agentic usage
+
+- Prefer `tilt get/describe/logs/trigger/wait` over parsing UI output.
+- Keep commands deterministic and resource-scoped when possible.
+- Collect status first, then logs, then trigger retries.
+- Treat `make dev-up` as idempotent for local loops.

--- a/.opencode/skills/tilt-dev.md
+++ b/.opencode/skills/tilt-dev.md
@@ -1,7 +1,7 @@
-# Tilt Dev Loop (Kind volcano-dev)
+# Tilt Dev Loop (Kind kind-volcano-dev)
 
 Use this skill to run and operate Volcano's local Tilt development loop on the
-Kind cluster named `volcano-dev`.
+Kind cluster named `kind-volcano-dev`, provisioned by `ctlptl` with a local registry.
 
 ## When to use
 
@@ -15,7 +15,7 @@ Kind cluster named `volcano-dev`.
 
 - Use repository root as the working directory.
 - Prefer project binaries from `_output/bin/` when available.
-- Keep cluster name fixed to `volcano-dev`.
+- Keep cluster name fixed to `kind-volcano-dev`.
 - Use `hack/tilt/Tiltfile` as the single Tilt entrypoint.
 
 ## Canonical workflow
@@ -27,8 +27,8 @@ make dev-up
 ```
 
 What this does:
-- Ensures `tilt` and `kind` binaries are available in `_output/bin/`.
-- Creates Kind cluster `volcano-dev` if missing.
+- Ensures `tilt`, `kind`, and `ctlptl` binaries are available in `_output/bin/`.
+- Creates/updates a `ctlptl`-managed Kind cluster + local registry from `hack/tilt/ctlptl-kind-registry.yaml`.
 - Runs `tilt up -f hack/tilt/Tiltfile`.
 
 2) Quick status snapshot
@@ -88,15 +88,15 @@ If `make dev-up` fails:
 1. Confirm cluster exists:
 
 ```bash
-_output/bin/kind get clusters
+_output/bin/ctlptl get cluster
 ```
 
-Expected: `volcano-dev` appears in the list.
+Expected: a cluster named `kind-volcano-dev` appears in the list.
 
 2. Confirm context matches Tiltfile expectation:
 
 ```bash
-kubectl config get-contexts -o name | grep -E '^(volcano-dev|kind-volcano-dev)$'
+kubectl config get-contexts -o name | grep -E '^(kind-volcano-dev|kind-kind-volcano-dev)$'
 ```
 
 3. Verify Tilt can see resources:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,412 @@
+# Volcano Developer Guide for AI Coding Agents
+
+This guide provides essential information for AI coding agents working on the Volcano codebase.
+
+## Project Overview
+
+Volcano is a Kubernetes-native batch scheduling system written in Go 1.24+. It extends kube-scheduler for AI/ML, Big Data, and HPC workloads. The project follows standard Go conventions with Kubernetes-specific patterns.
+
+## Build Commands
+
+### Core Binaries
+```bash
+# Build all components
+make all
+
+# Build individual components
+make vc-scheduler              # Batch scheduler (job/podgroup-level)
+make vc-agent-scheduler        # Agent scheduler (pod-level)
+make vc-controller-manager     # Controller manager
+make vc-webhook-manager        # Webhook admission controller
+make vc-agent                  # Agent node daemon (QoS, oversubscription)
+make vcctl                     # CLI tool
+
+# Build command-line utilities
+make command-lines             # vcancel, vresume, vsuspend, vjobs, vqueues, vsub
+
+# Clean build artifacts
+make clean
+```
+
+### Docker Images
+```bash
+# Build all images
+make images
+
+# Build individual component images
+make vc-scheduler-image
+make vc-agent-scheduler-image
+make vc-controller-manager-image
+make vc-webhook-manager-image
+make vc-agent-image
+```
+
+## Testing Commands
+
+### Unit Tests
+```bash
+# Run all unit tests
+make unit-test
+
+# Run tests for specific package
+go test -v volcano.sh/volcano/pkg/scheduler/cache
+
+# Run single test function
+go test -v volcano.sh/volcano/pkg/scheduler/cache -run TestGetOrCreateJob
+
+# Run with race detector
+go test -race volcano.sh/volcano/pkg/...
+
+# Clean test cache before running
+go clean -testcache
+```
+
+### E2E Tests
+```bash
+# Run all e2e tests
+make e2e
+
+# Run specific e2e test suites
+make e2e-test-schedulingbase
+make e2e-test-schedulingaction
+make e2e-test-jobp
+make e2e-test-jobseq
+make e2e-test-vcctl
+make e2e-test-stress
+make e2e-test-cronjob
+make e2e-test-admission-webhook
+```
+
+### Linting and Verification
+```bash
+# Run golangci-lint
+make lint
+
+# Verify formatting and generated code
+make verify
+
+# Verify generated YAML files
+make verify-generated-yaml
+
+# Check licenses
+make lint-licenses
+```
+
+## Code Style Guidelines
+
+### Import Organization
+
+Use **3-section imports** with blank lines between:
+
+```go
+import (
+    // Section 1: Standard library (alphabetically sorted)
+    "context"
+    "fmt"
+    "time"
+
+    // Section 2: Third-party packages (k8s.io, github.com, etc.)
+    v1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/client-go/kubernetes"
+
+    // Section 3: Local volcano.sh packages
+    batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+    "volcano.sh/volcano/pkg/scheduler/api"
+)
+```
+
+**Import prefix:** Use `goimports` with `local-prefixes: volcano.sh` (configured in .golangci.yml)
+
+### Naming Conventions
+
+- **Packages:** Short, lowercase, single word (e.g., `cache`, `scheduler`, `util`)
+- **Exported types:** PascalCase (e.g., `SchedulerCache`, `NodeInfo`, `TaskInfo`)
+- **Unexported types:** camelCase (e.g., `defaultEvictor`, `defaultBinder`)
+- **Interfaces:** Descriptive names, often ending in -er (e.g., `Binder`, `Evictor`, `StatusUpdater`)
+- **Functions:** PascalCase (exported) or camelCase (unexported), verb-noun pattern (e.g., `NewNodeInfo`, `AddTask`, `allocateIdleResource`)
+- **Variables:** Short names in local scope (e.g., `pg`, `sc`, `ni`, `err`, `ctx`), descriptive names at package level
+- **Test functions:** `Test<TypeName>_<MethodName>_<Scenario>` or `Test<FunctionName>`
+
+### Error Handling
+
+**Pattern A: Immediate return with context**
+```go
+if err != nil {
+    return fmt.Errorf("failed to find Job %v for Task %v", jobID, taskID)
+}
+```
+
+**Pattern B: Logging with klog**
+```go
+if err != nil {
+    klog.Errorf("Failed to update pod <%v/%v> status: %v", pod.Namespace, pod.Name, err)
+    return err
+}
+```
+
+**Pattern C: Error accumulation**
+```go
+if len(errs) != 0 {
+    return fmt.Errorf("failed to kill %d pods of %d", len(errs), total)
+}
+```
+
+**Guidelines:**
+- Use `fmt.Errorf` for error context (no error wrapping packages)
+- Use `klog` for structured logging with verbosity levels (V(3), V(4), etc.)
+- Check errors immediately: `if err != nil`
+- Never ignore errors without explicit justification
+
+### Comments and Documentation
+
+**File headers:** Apache 2.0 license (see existing files)
+
+**Function documentation:** GoDoc style (starts with function name)
+```go
+// New returns a Cache implementation that manages scheduler state.
+func New(config *rest.Config, ...) Cache { ... }
+
+// AddTask adds a task to the node and updates resource allocation.
+func (ni *NodeInfo) AddTask(task *TaskInfo) error { ... }
+```
+
+**Struct documentation:**
+```go
+// NodeInfo is node-level aggregated information including resources,
+// state, and scheduled tasks.
+type NodeInfo struct {
+    Name  string
+    State NodeState
+    // The releasing resource on that node
+    Releasing *Resource
+}
+```
+
+**Inline comments:** Explain "why" not "what", use sparingly for complex logic
+
+### Formatting
+
+- **Indentation:** Tabs (not spaces) - enforced by `gofmt`
+- **Line length:** No strict limit, but be reasonable (typically < 120 characters)
+- **Blank lines:** Separate logical blocks, one blank line between functions
+- **Whitespace:** Use `whitespace` linter settings (no trailing whitespace)
+
+### Test Patterns
+
+**Table-driven tests:**
+```go
+func TestKillJob(t *testing.T) {
+    testcases := []struct {
+        Name      string
+        Job       *v1alpha1.Job
+        ExpectVal error
+    }{
+        {
+            Name: "KillJob success case",
+            Job:  &v1alpha1.Job{...},
+            ExpectVal: nil,
+        },
+    }
+    for _, tc := range testcases {
+        t.Run(tc.Name, func(t *testing.T) {
+            // test logic
+        })
+    }
+}
+```
+
+**E2E tests:** Use Ginkgo/Gomega framework
+```go
+var _ = Describe("Job E2E Test", func() {
+    It("should run job successfully", func() {
+        Expect(err).NotTo(HaveOccurred())
+    })
+})
+```
+
+**Test helpers:** Use `build*` prefix for test object creation
+
+## Code Generation
+
+```bash
+# Generate code (CRDs, clients, informers, listers)
+make generate-code
+
+# Generate CRD manifests
+make manifests
+
+# Generate YAML files
+make generate-yaml
+
+# Generate Helm charts
+make generate-charts
+```
+
+## Agent Scheduler (vc-agent-scheduler)
+
+The agent-scheduler is a pod-level scheduler introduced alongside the traditional batch scheduler. While `vc-scheduler` operates on jobs and podgroups (batch scheduling), `vc-agent-scheduler` schedules individual pods one at a time per cycle, similar to kube-scheduler but with Volcano's plugin architecture.
+
+### Architecture Comparison
+
+| Aspect | `vc-scheduler` (Batch) | `vc-agent-scheduler` (Pod-level) |
+|---|---|---|
+| Scheduling unit | Jobs / PodGroups | Individual pods |
+| Package | `pkg/scheduler/` | `pkg/agentscheduler/` |
+| Plugin interface | `scheduler/framework.Plugin` | `agentscheduler/framework.Plugin` |
+| Action interface | `scheduler/framework.Action` | `agentscheduler/framework.Action` |
+| Default actions | enqueue, allocate, preempt, reclaim, backfill | allocate |
+| Default plugins | ~15+ (gang, proportion, predicates, nodeorder, etc.) | predicates, nodeorder |
+| Unique concepts | Jobs, Queues, PodGroups, gang scheduling | Sharding (ShardCoordinator), Workers, SchedulingContext |
+
+### Plugin and Action Interfaces
+
+The agent-scheduler has its own plugin and action interfaces distinct from the batch scheduler. When writing agent-scheduler plugins, use the interfaces from `pkg/agentscheduler/framework/`:
+
+**Action interface:**
+```go
+type Action interface {
+    Name() string
+    OnActionInit(configurations []conf.Configuration)
+    Initialize()
+    Execute(fwk *Framework, schedCtx *agentapi.SchedulingContext)
+    UnInitialize()
+}
+```
+
+**Plugin interface:**
+```go
+type Plugin interface {
+    Name() string
+    OnPluginInit(fwk *Framework)
+    OnCycleStart(fwk *Framework)
+    OnCycleEnd(fwk *Framework)
+}
+```
+
+Key differences from the batch scheduler:
+- Actions receive a `SchedulingContext` containing a single `TaskInfo` (one pod), not a full session
+- Plugins use `OnPluginInit`/`OnCycleStart`/`OnCycleEnd` instead of `OnSessionOpen`/`OnSessionClose`
+- The `BindContextHandler` interface allows plugins to inject bind-time extensions
+
+### Key Types
+
+```go
+// SchedulingContext contains all information needed for scheduling a task
+type SchedulingContext struct {
+    Task          *api.TaskInfo
+    QueuedPodInfo *framework.QueuedPodInfo
+    NodesInShard  sets.Set[string]
+}
+
+// BindContext carries plugin-specific bind extensions
+type BindContext struct {
+    SchedCtx   *SchedulingContext
+    Extensions map[string]cache.BindContextExtension
+}
+```
+
+### Default Configuration
+
+```yaml
+actions: "allocate"
+tiers:
+- plugins:
+  - name: predicates
+  - name: nodeorder
+```
+
+### Sharding Model
+
+The agent-scheduler supports node sharding via `ShardCoordinator`, allowing multiple scheduler instances to partition nodes for horizontal scaling. This concept has no equivalent in the batch scheduler.
+
+- `ShardCoordinator` tracks which nodes belong to this scheduler instance
+- Workers within a scheduler instance coordinate via revision-based node sets
+- Sharding mode is configured via `--sharding-mode` (supports `hard` and `soft` modes)
+- Node shard assignments are managed through `NodeShard` custom resources
+
+### Agent Node Daemon (vc-agent)
+
+The `vc-agent` binary (`pkg/agent/`) is a separate node-level daemon, unrelated to the agent-scheduler. It handles:
+- **QoS management**: CPU throttling, CPU burst, memory QoS, CPU QoS, network QoS
+- **Oversubscription**: Resource reporting and policy-based extend resources
+- **Node monitoring**: Resource calculation, node health probes
+- **Eviction**: Pod eviction based on node pressure
+
+The agent uses an event-driven architecture with probes (data sources) and handlers (actions):
+- Probes: `pkg/agent/events/probes/` (pods, noderesources, nodemonitor)
+- Handlers: `pkg/agent/events/handlers/` (cputhrottle, cpuburst, memoryqos, networkqos, eviction, etc.)
+- Configuration: File-based or ConfigMap-based config sources (`pkg/agent/config/`)
+
+## Commit Message Format
+
+Follow this convention:
+```
+<subsystem>: <what changed>
+
+<why this change was made>
+
+Fixes #<issue-number>
+```
+
+Example:
+```
+scheduler: add gang scheduling support for Ray jobs
+
+This enables Ray jobs to use gang scheduling to ensure all workers
+start together, improving resource utilization and reducing deadlocks.
+
+Fixes #1234
+```
+
+**Guidelines:**
+- Subject line ≤ 70 characters
+- Body wrapped at 80 characters
+- Focus on "why" not "what"
+
+## Linter Configuration
+
+Enabled linters (`.golangci.yml`):
+- `gofmt`, `goimports`, `govet` - Go standard checks
+- `staticcheck`, `gosimple`, `ineffassign` - Code quality
+- `typecheck`, `unused` - Type safety and dead code
+- `depguard` - Dependency restrictions (no `k8s.io/klog` v1, no `io/ioutil`)
+- `whitespace` - Formatting
+
+**Deprecated packages to avoid:**
+- `k8s.io/klog` → use `k8s.io/klog/v2`
+- `io/ioutil` → use `io` and `os` packages (Go 1.16+)
+
+## Key Directories
+
+- `cmd/` - Main applications (scheduler, agent-scheduler, controller-manager, webhook-manager, agent, cli)
+- `pkg/scheduler/` - Batch scheduler (job/podgroup-level scheduling)
+- `pkg/agentscheduler/` - Agent scheduler (pod-level scheduling, sharding)
+- `pkg/agent/` - Agent node daemon (QoS, oversubscription, eviction)
+- `pkg/controllers/` - Controllers
+- `pkg/webhooks/` - Webhooks
+- `test/e2e/` - End-to-end tests
+- `hack/` - Build and development scripts
+- `installer/` - Deployment manifests and Dockerfiles
+- `config/` - CRD definitions
+- `staging/src/volcano.sh/apis/` - API definitions (local development)
+
+## Additional Resources
+
+- [Contributing Guide](contribute.md)
+- [Development Setup](docs/development/prepare-for-development.md)
+- [Build Instructions](docs/development/development.md)
+
+## Pull Request Follow-Up Workflow
+
+When a pull request comment mentions an AI coding agent for follow-up work,
+use this lightweight workflow:
+
+1. Read the trigger comment first and identify the concrete request.
+2. Review newer review comments and CI status to avoid repeating stale fixes.
+3. Make only incremental changes on top of the PR branch.
+4. Validate the changed scope with targeted commands before posting updates.
+5. Summarize the change with clear verification results and next steps.
+
+This keeps follow-up iterations small, reviewable, and directly tied to the
+latest reviewer feedback.

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ DOCKER_PLATFORMS ?= "linux/${GOARCH}"
 
 GOOS ?= linux
 KIND_VERSION ?= v0.30.0
+CTLPTL_VERSION ?= 0.9.0
 
 include Makefile.def
 include hack/tilt/Makefile

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ endif
 DOCKER_PLATFORMS ?= "linux/${GOARCH}"
 
 GOOS ?= linux
+KIND_VERSION ?= v0.30.0
 
 include Makefile.def
 include hack/tilt/Makefile

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BIN_DIR=_output/bin
-RELEASE_DIR=_output/release
+OUTPUT_DIR=${PWD}/_output
+BIN_DIR=${OUTPUT_DIR}/bin
+RELEASE_DIR=${OUTPUT_DIR}/release
 REPO_PATH=volcano.sh/volcano
 IMAGE_PREFIX=volcanosh
 CRD_OPTIONS ?= "crd:crdVersions=v1,generateEmbeddedObjectMeta=true"
@@ -63,6 +64,7 @@ DOCKER_PLATFORMS ?= "linux/${GOARCH}"
 GOOS ?= linux
 
 include Makefile.def
+include hack/tilt/Makefile
 
 .EXPORT_ALL_VARIABLES:
 
@@ -217,7 +219,7 @@ release: images generate-yaml
 	./hack/publish.sh
 
 clean:
-	rm -rf _output/
+	rm -rf ${OUTPUT_DIR}/
 	rm -f *.log
 
 verify:

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,15 @@ DOCKER_PLATFORMS ?= "linux/${GOARCH}"
 
 GOOS ?= linux
 KIND_VERSION ?= v0.30.0
-CTLPTL_VERSION ?= 0.9.0
 
 include Makefile.def
 include hack/tilt/Makefile
 
 .EXPORT_ALL_VARIABLES:
+
+.PHONY: print-kind-version
+print-kind-version:
+	@printf "%s\n" "${KIND_VERSION}"
 
 all: vc-scheduler vc-agent-scheduler vc-controller-manager vc-webhook-manager vc-agent vcctl command-lines
 

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -15,11 +15,26 @@
 # limitations under the License.
 
 # spin up cluster with kind command
-function kind-up-cluster {
+function kind-create-cluster {
+  local kind_cmd=${KIND_BIN:-kind}
+
   check-kind
 
-  echo "Running kind: [kind create cluster ${CLUSTER_CONTEXT[*]} ${KIND_OPT}]"
-  kind create cluster "${CLUSTER_CONTEXT[@]}" ${KIND_OPT}
+  local cluster_name=${CLUSTER_CONTEXT[1]}
+
+  if ${kind_cmd} get clusters 2>/dev/null | grep -qw "${cluster_name}"; then
+    echo "Kind cluster ${cluster_name} already exists"
+  else
+    echo "Running kind: [${kind_cmd} create cluster ${CLUSTER_CONTEXT[*]} ${KIND_OPT}]"
+    ${kind_cmd} create cluster "${CLUSTER_CONTEXT[@]}" ${KIND_OPT}
+  fi
+
+  echo "Exporting kubeconfig for kind cluster ${cluster_name}"
+  ${kind_cmd} export kubeconfig --name "${cluster_name}" >/dev/null
+}
+
+function kind-up-cluster {
+  kind-create-cluster
 
   echo
   check-images
@@ -27,9 +42,9 @@ function kind-up-cluster {
   echo
   echo "Loading docker images into kind cluster"
   # only need to load images into control-plane node because volcano components are deployed on control-plane node.
-  kind load docker-image ${IMAGE_PREFIX}/vc-controller-manager:${TAG} "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
-  kind load docker-image ${IMAGE_PREFIX}/vc-scheduler:${TAG}          "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
-  kind load docker-image ${IMAGE_PREFIX}/vc-webhook-manager:${TAG}    "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+  ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-controller-manager:${TAG} "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+  ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-scheduler:${TAG}          "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+  ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-webhook-manager:${TAG}    "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
 }
 
 # check if the required images exist
@@ -66,13 +81,41 @@ function check-prerequisites {
 
 # check if kind installed
 function check-kind {
+  local kind_cmd=${KIND_BIN:-kind}
+  local required_version=${KIND_VERSION:-v0.30.0}
+
   echo "Checking kind"
-  which kind >/dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    echo "Installing kind ..."
-    GOOS=${OS} go install sigs.k8s.io/kind@v0.30.0
+  if command -v "${kind_cmd}" >/dev/null 2>&1; then
+    local found_version
+    found_version=$("${kind_cmd}" version | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    if [[ "${found_version}" == "${required_version}" ]]; then
+      echo "Found kind at ${kind_cmd}, version: ${found_version}"
+      return
+    fi
+
+    echo "Kind version mismatch at ${kind_cmd} (found ${found_version}, required ${required_version})"
   else
-    echo -n "Found kind, version: " && kind version
+    echo "Kind not found at ${kind_cmd}"
+  fi
+
+  if [[ -n "${KIND_BIN}" ]]; then
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+    case "${arch}" in
+      x86_64) arch=amd64 ;;
+      aarch64|arm64) arch=arm64 ;;
+    esac
+
+    echo "Installing kind ${required_version} to ${KIND_BIN} ..."
+    mkdir -p "$(dirname "${KIND_BIN}")"
+    curl -fsSL "https://github.com/kubernetes-sigs/kind/releases/download/${required_version}/kind-${os}-${arch}" -o "${KIND_BIN}"
+    chmod +x "${KIND_BIN}"
+    echo "Installed kind at ${KIND_BIN}"
+  else
+    echo "Installing kind ${required_version} via go install ..."
+    GOOS=${OS} go install sigs.k8s.io/kind@${required_version}
+    echo -n "Installed kind, version: " && kind version
   fi
 }
 

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -82,7 +82,17 @@ function check-prerequisites {
 # check if kind installed
 function check-kind {
   local kind_cmd=${KIND_BIN:-kind}
-  local required_version=${KIND_VERSION:-v0.30.0}
+  local required_version=${KIND_VERSION}
+
+  # If KIND_VERSION is not set, try to resolve it from Makefile in VK_ROOT
+  if [[ -z "${required_version}" ]] && [[ -n "${VK_ROOT}" ]] && [[ -f "${VK_ROOT}/Makefile" ]]; then
+    required_version=$(make -s -C "${VK_ROOT}" print-kind-version 2>/dev/null)
+  fi
+
+  if [[ -z "${required_version}" ]]; then
+    echo "ERROR: KIND_VERSION is not set and could not be resolved from Makefile"
+    return 1
+  fi
 
   echo "Checking kind"
   if command -v "${kind_cmd}" >/dev/null 2>&1; then

--- a/hack/tilt/Dockerfile.admission-init.tilt
+++ b/hack/tilt/Dockerfile.admission-init.tilt
@@ -1,0 +1,29 @@
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:latest
+ARG KUBE_VERSION="1.32.0"
+ARG TARGETARCH
+ARG APK_MIRROR
+RUN if [[ -n "$APK_MIRROR" ]]; then sed -i "s@https://dl-cdn.alpinelinux.org@${APK_MIRROR}@g" /etc/apk/repositories ; fi && \
+    apk add --update ca-certificates && \
+    apk add --update openssl && \
+    apk add --update -t deps curl && \
+    curl -L https://dl.k8s.io/release/v$KUBE_VERSION/bin/linux/$TARGETARCH/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    apk del --purge deps && \
+    rm /var/cache/apk/*
+
+ADD installer/dockerfile/webhook-manager/gen-admission-secret.sh /gen-admission-secret.sh
+ENTRYPOINT ["/gen-admission-secret.sh"]

--- a/hack/tilt/Dockerfile.tilt
+++ b/hack/tilt/Dockerfile.tilt
@@ -1,0 +1,41 @@
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.24.0
+
+ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
+ENV VOLCANO_HOME=/go/src/volcano.sh/volcano
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates openssl curl dumb-init less && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${VOLCANO_HOME}
+COPY go.mod go.sum ./
+COPY pkg/ ./pkg/
+COPY third_party/ ./third_party/
+COPY cmd/ ./cmd/
+COPY staging/ ./staging/
+COPY hack/tilt/entrypoint.sh ${VOLCANO_HOME}/entrypoint.sh
+
+RUN chmod +x ${VOLCANO_HOME}/entrypoint.sh
+RUN chown -R 1000:1000 ${VOLCANO_HOME}
+RUN useradd -u 1000 -m developer
+USER developer
+
+RUN go mod download
+RUN GOOS=linux GOARCH=amd64 go build -o ${VOLCANO_HOME}/vc-${COMPONENT} ./cmd/${COMPONENT}
+
+ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--", "/go/src/volcano.sh/volcano/entrypoint.sh"]

--- a/hack/tilt/Makefile
+++ b/hack/tilt/Makefile
@@ -1,0 +1,143 @@
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Makefile expects the following variables to be defined by the parent/root Makefile:
+# OUTPUT_DIR, BIN_DIR
+ifndef OUTPUT_DIR
+$(error OUTPUT_DIR is not set. Please define it in the parent Makefile.)
+endif
+
+ifndef BIN_DIR
+$(error BIN_DIR is not set. Please define it in the parent Makefile.)
+endif
+
+TILT_VERSION=0.35.1
+K3D_VERSION=v5.8.3
+TILT_BIN=${BIN_DIR}/tilt
+K3D_BIN=${BIN_DIR}/k3d
+
+K3D_DATA_DIR?=$(OUTPUT_DIR)/k3d-data
+K3D_CLUSTER_NAME ?= volcano-dev
+K3D_REGISTRY_NAME ?= volcano-registry
+K3D_REGISTRY_PORT ?= 5000
+K3D_SERVERS ?= 1
+K3D_AGENTS ?= 3
+K3D_API_PORT ?= 6510
+
+# Install Tilt if not present in _output/bin or wrong version
+dev-install-tilt:
+	@if [ ! -f ${TILT_BIN} ] || [ "$$(${TILT_BIN} version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "${TILT_VERSION}" ]; then \
+		curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.linux.x86_64.tar.gz | tar -xz && \
+		mv tilt ${TILT_BIN}; \
+		chmod +x ${TILT_BIN}; \
+		printf "Tilt installed at ${TILT_BIN} (version ${TILT_VERSION}).\n"; \
+	else \
+		printf "Tilt already installed at ${TILT_BIN} (version ${TILT_VERSION}).\n"; \
+	fi
+
+# Install k3d if not present in _output/bin or wrong version
+dev-install-k3d:
+	@if [ ! -f ${K3D_BIN} ] || [ "$$(${K3D_BIN} version | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "${K3D_VERSION}" ]; then \
+		curl -fsSL https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64 -o ${K3D_BIN}; \
+		chmod +x ${K3D_BIN}; \
+		printf "k3d installed at ${K3D_BIN} (version ${K3D_VERSION}).\n"; \
+	else \
+		printf "k3d already installed at ${K3D_BIN} (version ${K3D_VERSION}).\n"; \
+	fi
+
+# Create k3d cluster for local dev
+dev-create-k3d-cluster:
+	mkdir -pv $(K3D_DATA_DIR)/k3s_storage
+	mkdir -pv $(K3D_DATA_DIR)/machine-id-server-0
+	mkdir -pv $(K3D_DATA_DIR)/containerd/server-0
+	@for i in $$(seq 0 $$(($${K3D_AGENTS} - 1))); do \
+		mkdir -pv $(K3D_DATA_DIR)/containerd/agent-$$i; \
+		mkdir -pv $(K3D_DATA_DIR)/machine-id-agent-$$i; \
+    done
+	@( ${K3D_BIN} cluster list | grep -w $(K3D_CLUSTER_NAME) && echo "Cluster already exists." ) \
+	|| ${K3D_BIN} cluster create ${K3D_CLUSTER_NAME} \
+		--servers $(K3D_SERVERS) \
+		--agents $(K3D_AGENTS) \
+		--api-port $(K3D_API_PORT) \
+		--registry-use k3d-$(K3D_REGISTRY_NAME):$(K3D_REGISTRY_PORT) \
+		--no-lb \
+		--volume $(K3D_DATA_DIR)/k3s_storage:/var/lib/rancher/k3s/storage \
+		--volume $(K3D_DATA_DIR)/machine-id-server-0:/etc/machine-id@server:0 \
+		--volume $(K3D_DATA_DIR)/containerd/server-0:/var/lib/rancher/k3s/agent/containerd@server:0 \
+		$(foreach i,$(shell seq 0 $$(($(K3D_AGENTS)-1))),--volume $(K3D_DATA_DIR)/machine-id-agent-$(i):/etc/machine-id@agent:$(i) ) \
+		$(foreach i,$(shell seq 0 $$(($(K3D_AGENTS)-1))),--volume $(K3D_DATA_DIR)/containerd/agent-$(i):/var/lib/rancher/k3s/agent/containerd@agent:$(i) ) \
+		--wait 
+
+.PHONY: dev-start-k3d-cluster
+dev-start-k3d-cluster:
+	@${K3D_BIN} cluster start ${K3D_CLUSTER_NAME}
+
+.PHONY: dev-up
+dev-up: dev-install-tilt dev-install-k3d dev-registry-create
+	@cluster_status="$$($${K3D_BIN} cluster list | grep -w $${K3D_CLUSTER_NAME})"; \
+	if [ -n "$$cluster_status" ]; then \
+	    server_status=$$(echo "$$cluster_status" | awk '{print $$2}'); \
+        if echo "$$server_status" | grep -q '^0/'; then \
+            echo "Cluster exists but is stopped. Starting..."; \
+            $(MAKE) dev-start-k3d-cluster; \
+        else \
+            echo "Cluster already running."; \
+        fi; \
+	else \
+		$(MAKE) dev-create-k3d-cluster; \
+	fi;
+	$(TILT_BIN) up -f hack/tilt/Tiltfile
+
+.PHONY: dev-down
+dev-down: dev-stop-k3d-cluster
+
+.PHONY: dev-clean
+dev-clean: dev-delete-k3d-cluster dev-delete-registry
+	rm -rf $(K3D_DATA_DIR)
+	rm -f $(K3D_BIN) $(TILT_BIN)
+
+.PHONY: dev-stop-k3d-cluster
+dev-stop-k3d-cluster:
+	@${K3D_BIN} cluster stop ${K3D_CLUSTER_NAME} || true
+
+# Delete k3d cluster
+.PHONY: dev-delete-k3d-cluster
+dev-delete-k3d-cluster:
+	@${K3D_BIN} cluster delete ${K3D_CLUSTER_NAME} || true
+
+# Delete k3d cluster
+.PHONY: dev-delete-registry
+dev-delete-registry:
+	@${K3D_BIN} registry delete ${K3D_REGISTRY_NAME} || true
+
+# Stop local dev environment
+.PHONY: dev-down
+dev-down: dev-stop-k3d-cluster
+
+.PHONY: dev-registry-create
+dev-registry-create:
+	@( ${K3D_BIN} registry ls k3d-${K3D_REGISTRY_NAME} && echo "Local registry already exists." ) \
+	|| ${K3D_BIN} registry create ${K3D_REGISTRY_NAME} --port 0.0.0.0:${K3D_REGISTRY_PORT}
+
+.PHONY: dev-registry-delete
+dev-registry-delete:
+	${K3D_BIN} registry delete ${K3D_REGISTRY_NAME}
+
+.PHONY: dev-status
+dev-status:
+	${K3D_BIN} registry ls
+	@echo ---
+	${K3D_BIN} cluster ls
+
+

--- a/hack/tilt/Makefile
+++ b/hack/tilt/Makefile
@@ -23,17 +23,59 @@ $(error BIN_DIR is not set. Please define it in the parent Makefile.)
 endif
 
 TILT_VERSION=0.35.1
-K3D_VERSION=v5.8.3
+KIND_VERSION ?= v0.30.0
 TILT_BIN=${BIN_DIR}/tilt
-K3D_BIN=${BIN_DIR}/k3d
+KIND_BIN=${BIN_DIR}/kind
 
-K3D_DATA_DIR?=$(OUTPUT_DIR)/k3d-data
-K3D_CLUSTER_NAME ?= volcano-dev
-K3D_REGISTRY_NAME ?= volcano-registry
-K3D_REGISTRY_PORT ?= 5000
-K3D_SERVERS ?= 1
-K3D_AGENTS ?= 3
-K3D_API_PORT ?= 6510
+KIND_CLUSTER_NAME ?= volcano-dev
+KIND_CONTEXT_NAME ?= ${KIND_CLUSTER_NAME}
+KIND_CONFIG ?= hack/e2e-kind-config.yaml
+
+TILT_WAIT_TIMEOUT ?= 10m
+TILT_WAIT_RESOURCES ?= \
+	uiresource/uncategorized \
+	uiresource/volcano-namespaces \
+	uiresource/volcano-crds \
+	uiresource/volcano-vcjob-roles \
+	uiresource/volcano-admission-init \
+	uiresource/volcano-admission \
+	uiresource/volcano-scheduler \
+	uiresource/volcano-controllers \
+	uiresource/prometheus-deployment \
+	uiresource/kube-state-metrics \
+	uiresource/grafana
+
+# Install Kind if not present in _output/bin or wrong version
+dev-install-kind:
+	@PATH="${BIN_DIR}:$$PATH" KIND_BIN="${KIND_BIN}" KIND_VERSION="${KIND_VERSION}" bash -c 'source hack/lib/install.sh; check-kind'
+
+# Create Kind cluster for local dev
+dev-create-kind-cluster:
+	@PATH="${BIN_DIR}:$$PATH" bash -c 'source hack/lib/install.sh; CLUSTER_CONTEXT=("--name" "${KIND_CLUSTER_NAME}"); KIND_OPT="--config ${KIND_CONFIG} --wait 5m"; kind-create-cluster'
+
+.PHONY: dev-up
+dev-up: dev-install-tilt dev-install-kind
+	$(MAKE) dev-create-kind-cluster
+	$(TILT_BIN) up -f hack/tilt/Tiltfile
+
+.PHONY: dev-down
+dev-down:
+	@$(TILT_BIN) down -f hack/tilt/Tiltfile 2>/dev/null || true
+
+# Delete Kind cluster
+.PHONY: dev-delete-kind-cluster
+dev-delete-kind-cluster:
+	@${KIND_BIN} delete cluster --name ${KIND_CLUSTER_NAME} || true
+
+.PHONY: dev-clean
+dev-clean: dev-down dev-delete-kind-cluster
+	rm -f $(KIND_BIN) $(TILT_BIN)
+
+.PHONY: dev-status
+dev-status:
+	${KIND_BIN} get clusters
+	@echo ---
+	@kubectl cluster-info --context ${KIND_CONTEXT_NAME} 2>/dev/null || kubectl cluster-info --context kind-${KIND_CLUSTER_NAME} 2>/dev/null || echo "Cluster not running."
 
 # Install Tilt if not present in _output/bin or wrong version
 dev-install-tilt:
@@ -46,98 +88,34 @@ dev-install-tilt:
 		printf "Tilt already installed at ${TILT_BIN} (version ${TILT_VERSION}).\n"; \
 	fi
 
-# Install k3d if not present in _output/bin or wrong version
-dev-install-k3d:
-	@if [ ! -f ${K3D_BIN} ] || [ "$$(${K3D_BIN} version | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "${K3D_VERSION}" ]; then \
-		curl -fsSL https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64 -o ${K3D_BIN}; \
-		chmod +x ${K3D_BIN}; \
-		printf "k3d installed at ${K3D_BIN} (version ${K3D_VERSION}).\n"; \
+.PHONY: dev-tilt-status
+dev-tilt-status: dev-install-tilt
+	${TILT_BIN} get uiresource
+
+.PHONY: dev-tilt-logs
+dev-tilt-logs: dev-install-tilt
+	@if [ -n "${RESOURCE}" ]; then \
+		${TILT_BIN} logs ${RESOURCE}; \
 	else \
-		printf "k3d already installed at ${K3D_BIN} (version ${K3D_VERSION}).\n"; \
+		${TILT_BIN} logs; \
 	fi
 
-# Create k3d cluster for local dev
-dev-create-k3d-cluster:
-	mkdir -pv $(K3D_DATA_DIR)/k3s_storage
-	mkdir -pv $(K3D_DATA_DIR)/machine-id-server-0
-	mkdir -pv $(K3D_DATA_DIR)/containerd/server-0
-	@for i in $$(seq 0 $$(($${K3D_AGENTS} - 1))); do \
-		mkdir -pv $(K3D_DATA_DIR)/containerd/agent-$$i; \
-		mkdir -pv $(K3D_DATA_DIR)/machine-id-agent-$$i; \
-    done
-	@( ${K3D_BIN} cluster list | grep -w $(K3D_CLUSTER_NAME) && echo "Cluster already exists." ) \
-	|| ${K3D_BIN} cluster create ${K3D_CLUSTER_NAME} \
-		--servers $(K3D_SERVERS) \
-		--agents $(K3D_AGENTS) \
-		--api-port $(K3D_API_PORT) \
-		--registry-use k3d-$(K3D_REGISTRY_NAME):$(K3D_REGISTRY_PORT) \
-		--no-lb \
-		--volume $(K3D_DATA_DIR)/k3s_storage:/var/lib/rancher/k3s/storage \
-		--volume $(K3D_DATA_DIR)/machine-id-server-0:/etc/machine-id@server:0 \
-		--volume $(K3D_DATA_DIR)/containerd/server-0:/var/lib/rancher/k3s/agent/containerd@server:0 \
-		$(foreach i,$(shell seq 0 $$(($(K3D_AGENTS)-1))),--volume $(K3D_DATA_DIR)/machine-id-agent-$(i):/etc/machine-id@agent:$(i) ) \
-		$(foreach i,$(shell seq 0 $$(($(K3D_AGENTS)-1))),--volume $(K3D_DATA_DIR)/containerd/agent-$(i):/var/lib/rancher/k3s/agent/containerd@agent:$(i) ) \
-		--wait 
+.PHONY: dev-tilt-describe
+dev-tilt-describe: dev-install-tilt
+	@if [ -z "${RESOURCE}" ]; then \
+		echo "RESOURCE is required. Example: make dev-tilt-describe RESOURCE=volcano-scheduler"; \
+		exit 1; \
+	fi
+	${TILT_BIN} describe uiresource ${RESOURCE}
 
-.PHONY: dev-start-k3d-cluster
-dev-start-k3d-cluster:
-	@${K3D_BIN} cluster start ${K3D_CLUSTER_NAME}
+.PHONY: dev-tilt-trigger
+dev-tilt-trigger: dev-install-tilt
+	@if [ -z "${RESOURCE}" ]; then \
+		echo "RESOURCE is required. Example: make dev-tilt-trigger RESOURCE=volcano-scheduler"; \
+		exit 1; \
+	fi
+	${TILT_BIN} trigger ${RESOURCE}
 
-.PHONY: dev-up
-dev-up: dev-install-tilt dev-install-k3d dev-registry-create
-	@cluster_status="$$($${K3D_BIN} cluster list | grep -w $${K3D_CLUSTER_NAME})"; \
-	if [ -n "$$cluster_status" ]; then \
-	    server_status=$$(echo "$$cluster_status" | awk '{print $$2}'); \
-        if echo "$$server_status" | grep -q '^0/'; then \
-            echo "Cluster exists but is stopped. Starting..."; \
-            $(MAKE) dev-start-k3d-cluster; \
-        else \
-            echo "Cluster already running."; \
-        fi; \
-	else \
-		$(MAKE) dev-create-k3d-cluster; \
-	fi;
-	$(TILT_BIN) up -f hack/tilt/Tiltfile
-
-.PHONY: dev-down
-dev-down: dev-stop-k3d-cluster
-
-.PHONY: dev-clean
-dev-clean: dev-delete-k3d-cluster dev-delete-registry
-	rm -rf $(K3D_DATA_DIR)
-	rm -f $(K3D_BIN) $(TILT_BIN)
-
-.PHONY: dev-stop-k3d-cluster
-dev-stop-k3d-cluster:
-	@${K3D_BIN} cluster stop ${K3D_CLUSTER_NAME} || true
-
-# Delete k3d cluster
-.PHONY: dev-delete-k3d-cluster
-dev-delete-k3d-cluster:
-	@${K3D_BIN} cluster delete ${K3D_CLUSTER_NAME} || true
-
-# Delete k3d cluster
-.PHONY: dev-delete-registry
-dev-delete-registry:
-	@${K3D_BIN} registry delete ${K3D_REGISTRY_NAME} || true
-
-# Stop local dev environment
-.PHONY: dev-down
-dev-down: dev-stop-k3d-cluster
-
-.PHONY: dev-registry-create
-dev-registry-create:
-	@( ${K3D_BIN} registry ls k3d-${K3D_REGISTRY_NAME} && echo "Local registry already exists." ) \
-	|| ${K3D_BIN} registry create ${K3D_REGISTRY_NAME} --port 0.0.0.0:${K3D_REGISTRY_PORT}
-
-.PHONY: dev-registry-delete
-dev-registry-delete:
-	${K3D_BIN} registry delete ${K3D_REGISTRY_NAME}
-
-.PHONY: dev-status
-dev-status:
-	${K3D_BIN} registry ls
-	@echo ---
-	${K3D_BIN} cluster ls
-
-
+.PHONY: dev-wait-ready
+dev-wait-ready: dev-install-tilt
+	${TILT_BIN} wait --for=condition=Ready ${TILT_WAIT_RESOURCES} --timeout=${TILT_WAIT_TIMEOUT}

--- a/hack/tilt/Makefile
+++ b/hack/tilt/Makefile
@@ -24,12 +24,14 @@ endif
 
 TILT_VERSION=0.35.1
 KIND_VERSION ?= v0.30.0
+CTLPTL_VERSION ?= 0.9.0
 TILT_BIN=${BIN_DIR}/tilt
 KIND_BIN=${BIN_DIR}/kind
+CTLPTL_BIN=${BIN_DIR}/ctlptl
 
-KIND_CLUSTER_NAME ?= volcano-dev
+KIND_CLUSTER_NAME ?= kind-volcano-dev
 KIND_CONTEXT_NAME ?= ${KIND_CLUSTER_NAME}
-KIND_CONFIG ?= hack/e2e-kind-config.yaml
+CTLPTL_CONFIG ?= hack/tilt/ctlptl-kind-registry.yaml
 
 TILT_WAIT_TIMEOUT ?= 10m
 TILT_WAIT_RESOURCES ?= \
@@ -49,31 +51,43 @@ TILT_WAIT_RESOURCES ?= \
 dev-install-kind:
 	@PATH="${BIN_DIR}:$$PATH" KIND_BIN="${KIND_BIN}" KIND_VERSION="${KIND_VERSION}" bash -c 'source hack/lib/install.sh; check-kind'
 
-# Create Kind cluster for local dev
+# Install ctlptl if not present in _output/bin or wrong version
+dev-install-ctlptl:
+	@if [ ! -f ${CTLPTL_BIN} ] || [ "$$(${CTLPTL_BIN} version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "${CTLPTL_VERSION}" ]; then \
+		mkdir -p ${BIN_DIR}; \
+		curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v${CTLPTL_VERSION}/ctlptl.${CTLPTL_VERSION}.linux.x86_64.tar.gz | tar -xz -C ${BIN_DIR} ctlptl; \
+		chmod +x ${CTLPTL_BIN}; \
+		printf "ctlptl installed at ${CTLPTL_BIN} (version ${CTLPTL_VERSION}).\n"; \
+	else \
+		printf "ctlptl already installed at ${CTLPTL_BIN} (version ${CTLPTL_VERSION}).\n"; \
+	fi
+
+# Create Kind cluster and registry for local dev via ctlptl
 dev-create-kind-cluster:
-	@PATH="${BIN_DIR}:$$PATH" bash -c 'source hack/lib/install.sh; CLUSTER_CONTEXT=("--name" "${KIND_CLUSTER_NAME}"); KIND_OPT="--config ${KIND_CONFIG} --wait 5m"; kind-create-cluster'
+	${CTLPTL_BIN} apply -f ${CTLPTL_CONFIG}
 
 .PHONY: dev-up
-dev-up: dev-install-tilt dev-install-kind
+dev-up: dev-install-tilt dev-install-kind dev-install-ctlptl
 	$(MAKE) dev-create-kind-cluster
 	$(TILT_BIN) up -f hack/tilt/Tiltfile
 
 .PHONY: dev-down
 dev-down:
 	@$(TILT_BIN) down -f hack/tilt/Tiltfile 2>/dev/null || true
+	@pkill -f '^${TILT_BIN} up -f hack/tilt/Tiltfile$$' || true
 
-# Delete Kind cluster
+# Delete Kind cluster and registry managed by ctlptl
 .PHONY: dev-delete-kind-cluster
 dev-delete-kind-cluster:
-	@${KIND_BIN} delete cluster --name ${KIND_CLUSTER_NAME} || true
+	@${CTLPTL_BIN} delete -f ${CTLPTL_CONFIG} --cascade=true --ignore-not-found || true
 
 .PHONY: dev-clean
 dev-clean: dev-down dev-delete-kind-cluster
-	rm -f $(KIND_BIN) $(TILT_BIN)
+	rm -f $(KIND_BIN) $(CTLPTL_BIN) $(TILT_BIN)
 
 .PHONY: dev-status
 dev-status:
-	${KIND_BIN} get clusters
+	${CTLPTL_BIN} get cluster
 	@echo ---
 	@kubectl cluster-info --context ${KIND_CONTEXT_NAME} 2>/dev/null || kubectl cluster-info --context kind-${KIND_CLUSTER_NAME} 2>/dev/null || echo "Cluster not running."
 

--- a/hack/tilt/Makefile
+++ b/hack/tilt/Makefile
@@ -23,11 +23,14 @@ $(error BIN_DIR is not set. Please define it in the parent Makefile.)
 endif
 
 TILT_VERSION=0.35.1
-KIND_VERSION ?= v0.30.0
 CTLPTL_VERSION ?= 0.9.0
 TILT_BIN=${BIN_DIR}/tilt
 KIND_BIN=${BIN_DIR}/kind
 CTLPTL_BIN=${BIN_DIR}/ctlptl
+
+ifndef KIND_VERSION
+$(error KIND_VERSION is not set. Please define it in the parent Makefile.)
+endif
 
 KIND_CLUSTER_NAME ?= kind-volcano-dev
 KIND_CONTEXT_NAME ?= ${KIND_CLUSTER_NAME}

--- a/hack/tilt/Tiltfile
+++ b/hack/tilt/Tiltfile
@@ -1,0 +1,306 @@
+# Tiltfile for Volcano
+
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ensure k3d cluster exists for local dev
+k3d_cluster_name = 'k3d-volcano-dev'
+allow_k8s_contexts(k3d_cluster_name)
+
+# Set the default namespace for all resources
+k8s_namespace('volcano-system')
+
+# Apply namespace manifest
+root_dir = '../../'
+k8s_yaml(root_dir + 'installer/namespace.yaml')
+
+# Helm-based installation (using helm() pattern)
+volcano_yaml = helm(
+    root_dir + 'installer/helm/chart/volcano',
+    name='volcano',
+    namespace='volcano-system',
+    values=[root_dir + 'installer/helm/chart/volcano/values.yaml', 'values-tilt-override.yaml'],
+    set=[
+        'basic.admission_init_image_name=volcanosh/vc-admission-init',
+    ]
+)
+k8s_yaml(volcano_yaml)
+
+k8s_yaml(root_dir + 'installer/volcano-monitoring.yaml')
+
+# Build all images for local registry
+images = [
+    ('volcanosh/vc-scheduler', root_dir, 'scheduler'),
+    ('volcanosh/vc-controller-manager', root_dir, 'controller-manager'),
+    ('volcanosh/vc-webhook-manager', root_dir, 'webhook-manager'),
+]
+for name, path, component in images:
+    docker_build(
+        name,
+        path,
+        build_args=dict(COMPONENT=component),
+        dockerfile='Dockerfile.tilt',
+        only=['./pkg/', './third_party/', './cmd/'+ component, './staging/', './hack/tilt/entrypoint.sh', 'go.mod', 'go.sum'],
+        live_update=[
+            sync(root_dir + './pkg', '/go/src/volcano.sh/volcano/pkg'),
+            sync(root_dir + './third_party', '/go/src/volcano.sh/volcano/third_party'),
+            sync(root_dir + './cmd/' + component, '/go/src/volcano.sh/volcano/cmd/' + component),
+            sync(root_dir + './hack/tilt/entrypoint.sh', '/go/src/volcano.sh/volcano/entrypoint.sh'),
+            run('touch /tmp/reload')
+        ]
+    )
+
+docker_build(
+    'volcanosh/vc-admission-init',
+    root_dir,
+    dockerfile='Dockerfile.admission-init.tilt',
+    only=["./installer/dockerfile/webhook-manager/gen-admission-secret.sh"],
+)
+
+
+# Group all namespaces
+k8s_resource(
+    new_name='volcano-namespaces',
+    objects=[
+        'volcano-system:namespace',
+        'volcano-monitoring:namespace',
+    ],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    new_name='volcano-crds',
+    objects=[
+        'jobtemplates.flow.volcano.sh:customresourcedefinition',
+        'jobflows.flow.volcano.sh:customresourcedefinition',
+        'jobs.batch.volcano.sh:customresourcedefinition',
+        'commands.bus.volcano.sh:customresourcedefinition',
+        'numatopologies.nodeinfo.volcano.sh:customresourcedefinition',
+        'podgroups.scheduling.volcano.sh:customresourcedefinition',
+        'queues.scheduling.volcano.sh:customresourcedefinition',
+        'hypernodes.topology.volcano.sh:customresourcedefinition',
+        'cronjobs.batch.volcano.sh:customresourcedefinition',
+        'nodeshards.shard.volcano.sh:customresourcedefinition'
+    ],
+    labels=["volcano"]
+)
+
+
+# Group all admission-related resources
+k8s_resource(
+    'volcano-admission',
+    objects=[
+        'volcano-admission:serviceaccount',
+        'volcano-admission:clusterrole',
+        'volcano-admission-role:clusterrolebinding',
+        'volcano-admission-configmap:configmap',
+        'volcano-admission-service-queues-mutate:mutatingwebhookconfiguration',
+        'volcano-admission-service-jobs-mutate:mutatingwebhookconfiguration',
+        'volcano-admission-service-jobs-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-queues-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-podgroups-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-hypernodes-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-cronjobs-validate:validatingwebhookconfiguration'
+    ],
+    resource_deps=['volcano-namespaces', 'volcano-crds', 'volcano-admission-init'],
+    labels=["volcano"]
+)
+
+# Group all admission-related resources
+k8s_resource(
+    'volcano-scheduler',
+    objects=[
+        'volcano-scheduler:serviceaccount',
+        'volcano-scheduler:clusterrole',
+        'volcano-scheduler-role:clusterrolebinding',
+        'volcano-scheduler-configmap:configmap',
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["volcano"]
+)
+
+# Group controller resources
+k8s_resource(
+    'volcano-controllers',
+    objects=[
+        'volcano-controllers:serviceaccount',
+        'volcano-controllers:clusterrole',
+        'volcano-controllers-role:clusterrolebinding',
+        'volcano-controller-configmap:configmap'
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    new_name='volcano-vcjob-roles',
+    objects=[
+        'vcjob-editor-role:clusterrole',
+        'vcjob-viewer-role:clusterrole'
+    ],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    'volcano-admission-init',
+    extra_pod_selectors=[{'job-name': 'volcano-admission-init'}],
+    objects=[
+        'volcano-admission-init:serviceaccount',
+        'volcano-admission-init:role',
+        'volcano-admission-init-role:rolebinding',
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    'prometheus-deployment',
+    objects=[
+        'prometheus-volcano:clusterrolebinding',
+        'prometheus-volcano:clusterrole',
+        'prometheus-server-conf:configmap'
+    ],
+    resource_deps=['volcano-namespaces'],
+    port_forwards=3001,
+    labels=["monitoring"]    
+)
+
+k8s_resource(
+    'kube-state-metrics',
+    objects=[
+        'kube-state-metrics:serviceaccount',
+        'kube-state-metrics:clusterrole',
+        'kube-state-metrics:clusterrolebinding',
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["monitoring"]
+)
+
+k8s_resource(
+    'grafana',
+    objects=[
+        'grafana-datasources:configmap',
+        'grafana-volcano-dashboard-config:configmap',
+        'grafana-volcano-dashboard:configmap',
+    ],
+    resource_deps=['volcano-namespaces'],
+    port_forwards=3000,
+    labels=["monitoring"]
+)
+
+local_resource(
+    'install-kwok',
+    'bash -c "source ' + root_dir + 'hack/lib/install.sh && install-kwok-with-helm"',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests-install"]
+)
+
+local_resource(
+    'install-ginkgo',
+    'bash -c "source ' + root_dir + 'hack/lib/install.sh && install-ginkgo-if-not-exist"',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests-install"]
+)
+
+# Optionally, run e2e tests (using local_resource)
+local_resource(
+    'unit-tests',
+    'make unit-test',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-all',
+    '''
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ''' + root_dir + '''test/e2e/jobp/
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ''' + root_dir + '''test/e2e/jobseq/
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ''' + root_dir + '''test/e2e/schedulingbase/
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ''' + root_dir + '''test/e2e/schedulingaction/
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ''' + root_dir + '''test/e2e/vcctl/
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress --focus="DRA E2E Test" ''' + root_dir + '''test/e2e/dra/
+    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ''' + root_dir + '''test/e2e/hypernode/
+    ''',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-kwok']
+)
+
+local_resource(
+    'e2e-tests-jobp',
+    "KUBECONFIG=${KUBECONFIG} ginkgo -v -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress " + root_dir + "./test/e2e/jobp/",
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-jobseq',
+    "KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold='30s' --progress " + root_dir + "./test/e2e/jobseq/",
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-schedulingbase',
+    "KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold='30s' --progress " + root_dir + "./test/e2e/schedulingbase/",
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-schedulingaction',
+    "KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold='30s' --progress " + root_dir + "./test/e2e/schedulingaction/",
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-vcctl',
+    "KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold='30s' --progress " + root_dir + "./test/e2e/vcctl/",
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-dra',
+    'KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold="30s" --progress --focus="DRA E2E Test" ' + root_dir + './test/e2e/dra/',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-hypernode',
+    'KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold="30s" --progress ' + root_dir + './test/e2e/hypernode/',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-cronjob',
+    "KUBECONFIG=${KUBECONFIG} ginkgo -v -r --slow-spec-threshold='30s' --progress " + root_dir + "test/e2e/cronjob/",
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)

--- a/hack/tilt/Tiltfile
+++ b/hack/tilt/Tiltfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Ensure Kind cluster exists for local dev
-kind_cluster_name = 'volcano-dev'
+kind_cluster_name = 'kind-volcano-dev'
 allow_k8s_contexts([kind_cluster_name, 'kind-' + kind_cluster_name])
 
 # Set the default namespace for all resources

--- a/hack/tilt/Tiltfile
+++ b/hack/tilt/Tiltfile
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ensure k3d cluster exists for local dev
-k3d_cluster_name = 'k3d-volcano-dev'
-allow_k8s_contexts(k3d_cluster_name)
+# Ensure Kind cluster exists for local dev
+kind_cluster_name = 'volcano-dev'
+allow_k8s_contexts([kind_cluster_name, 'kind-' + kind_cluster_name])
 
 # Set the default namespace for all resources
 k8s_namespace('volcano-system')

--- a/hack/tilt/ctlptl-kind-registry.yaml
+++ b/hack/tilt/ctlptl-kind-registry.yaml
@@ -1,0 +1,18 @@
+apiVersion: ctlptl.dev/v1alpha1
+kind: Registry
+name: volcano-registry
+port: 5005
+---
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: kind-volcano-dev
+product: kind
+registry: volcano-registry
+kindV1Alpha4Cluster:
+  name: kind-volcano-dev
+  nodes:
+    - role: control-plane
+    - role: worker
+    - role: worker
+    - role: worker
+    - role: worker

--- a/hack/tilt/entrypoint.sh
+++ b/hack/tilt/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SRC_DIR=/go/src/volcano.sh/volcano
+BIN="${SRC_DIR}/vc-${COMPONENT}"
+RELOAD_FILE="/tmp/reload"
+
+child_pid=0
+
+start_child() {
+  "$BIN" "$@" &
+  child_pid=$!
+}
+
+stop_child() {
+  if [ $child_pid -ne 0 ]; then
+    kill $child_pid
+    wait $child_pid 2>/dev/null || true
+  fi
+}
+
+start_child "$@"
+
+while true; do
+  if [ -f "$RELOAD_FILE" ]; then
+    echo "[entrypoint] Detected reload trigger, rebuilding and restarting..."
+    stop_child
+    GOOS=linux GOARCH=amd64 go build -o "$BIN" ./cmd/${COMPONENT}
+    start_child "$@"
+    rm -f "$RELOAD_FILE"
+  fi
+  sleep 1
+done

--- a/hack/tilt/values-tilt-override.yaml
+++ b/hack/tilt/values-tilt-override.yaml
@@ -1,0 +1,33 @@
+basic:
+  image_pull_policy: IfNotPresent
+  scheduler_config_file: config/volcano-scheduler-ci.conf
+
+custom:
+  controller_log_level: 5
+  scheduler_log_level: 5
+  scheduler_schedule_period: 1s
+  admission_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  controller_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  scheduler_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  default_ns:
+    node-role.kubernetes.io/control-plane: "true"
+  # scheduler_feature_gates: ${FEATURE_GATES}
+  # ignored_provisioners: ${IGNORED_PROVISIONERS:-""}

--- a/hack/tilt/values-tilt-override.yaml
+++ b/hack/tilt/values-tilt-override.yaml
@@ -28,6 +28,6 @@ custom:
       operator: "Exists"
       effect: "NoSchedule"
   default_ns:
-    node-role.kubernetes.io/control-plane: "true"
+    node-role.kubernetes.io/control-plane: ""
   # scheduler_feature_gates: ${FEATURE_GATES}
   # ignored_provisioners: ${IGNORED_PROVISIONERS:-""}

--- a/installer/helm/chart/volcano/templates/admission-init.yaml
+++ b/installer/helm/chart/volcano/templates/admission-init.yaml
@@ -107,7 +107,7 @@ spec:
           resources:
           {{- toYaml .Values.custom.admission_resources | nindent 12 }}
           {{- end }}
-          image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}
+          image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_init_image_name}}:{{.Values.basic.image_tag_version}}
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           command: ["./gen-admission-secret.sh", "--service", "{{ .Release.Name }}-admission-service", "--namespace",
                     "{{ .Release.Namespace }}", "--secret", "{{.Values.basic.admission_secret_name}}"]

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -3,6 +3,7 @@ basic:
   scheduler_image_name: "volcanosh/vc-scheduler"
   agent_scheduler_image_name: "volcanosh/vc-agent-scheduler"
   admission_image_name: "volcanosh/vc-webhook-manager"
+  admission_init_image_name: "volcanosh/vc-webhook-manager"
   agent_image_name: "volcanosh/vc-agent"
   admission_secret_name: "volcano-admission-secret"
   admission_config_file: "config/volcano-admission.conf"


### PR DESCRIPTION
## Summary
- Port local Tilt workflow from k3d to Kind with `volcano-dev` defaults and context compatibility.
- Add agentic Tilt make targets for status, logs, describe, trigger, and readiness wait.
- Unify Kind installation/version flow by making `check-kind` consume Makefile-provided `KIND_VERSION`/`KIND_BIN`.

## Verification
- `make dev-install-kind`
- `make dev-create-kind-cluster`
- `make dev-up`
- `make dev-tilt-status`
- `make dev-wait-ready`
- `make dev-down`
- `make dev-delete-kind-cluster`