### PR TITLE
[Proposal] Tilt-based local development workflow with Kind

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+_output/
+_output

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,16 @@ endif
 DOCKER_PLATFORMS ?= "linux/${GOARCH}"
 
 GOOS ?= linux
+KIND_VERSION ?= v0.31.0
 
 include Makefile.def
+include hack/tilt/Makefile
 
 .EXPORT_ALL_VARIABLES:
+
+.PHONY: print-kind-version
+print-kind-version:
+	@printf "%s\n" "${KIND_VERSION}"
 
 all: vc-scheduler vc-agent-scheduler vc-controller-manager vc-webhook-manager vc-agent vcctl command-lines
 
@@ -220,7 +226,7 @@ e2e-test-vcctl: vcctl images
 e2e-test-stress: images
 	E2E_TYPE=STRESS ./hack/run-e2e-kind.sh
 
-e2e-test-cronjob: images  
+e2e-test-cronjob: images
 	E2E_TYPE=CRONJOB ./hack/run-e2e-kind.sh
 
 e2e-test-dra: images
@@ -257,7 +263,7 @@ release: images generate-yaml
 	./hack/publish.sh
 
 clean:
-	rm -rf _output/
+	rm -rf ${OUTPUT_DIR}/
 	rm -f *.log
 
 verify:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ You can try Volcano by one of the following two ways.
 > * For Kubernetes v1.17 and above, use CRDs under config/crd/bases (recommended)
 > * For Kubernetes v1.16 and below, use CRDs under config/crd/v1beta1 (deprecated)
 
+### Development with Tilt (Recommended for contributors)
+
+The fastest way to get a full development environment is with the Tilt-based workflow.
+It provisions a Kind cluster with a local registry and deploys all Volcano components
+with live-reload — edit any Go file and the running component rebuilds automatically:
+
+```bash
+make dev-up    # Provisions cluster + starts Tilt (first run ~20-25 min)
+```
+
+**Prerequisites:** Docker and Make. No local Go toolchain is required for building — builds
+happen inside containers. However, installing Go locally is recommended for running unit
+tests and working with the project long-term.
+
+For the full workflow reference, see the [development guide](docs/development/development.md).
+For architecture and design rationale, see the [design proposal](docs/design/tilt-based-development.md).
+
 ### Install with YAML files
 
 Install Volcano on an existing Kubernetes cluster. This way is both available for x86_64 and arm64 architecture.
@@ -155,7 +172,7 @@ helm list -n volcano-system
 
 ### Install from code
 
-If you don't have a kubernetes cluster, try one-click install from code base:
+If you don't have a kubernetes cluster, and you don't want the live-reload tilt environment, you can try the legacy one-click install from code base:
 
 ```bash
 ./hack/local-up-volcano.sh

--- a/docs/design/tilt-based-development.md
+++ b/docs/design/tilt-based-development.md
@@ -1,0 +1,535 @@
+# Tilt-Based Local Development Workflow
+
+## Motivation
+
+### Problem
+
+Developing and testing Volcano components locally requires building Docker images, pushing them to a registry, deploying to a Kubernetes cluster, and restarting pods for every code change. This cycle is slow and error-prone, creating friction for contributors who need fast feedback loops during scheduler, controller, or webhook development.
+
+The existing `hack/local-up-volcano.sh` script provides a one-shot local cluster setup, but it does not support iterative development. Each code change requires tearing down and rebuilding the environment, which can take several minutes.
+
+### Design Goal
+
+1. Enable sub-minute code-to-running-pod feedback for all Volcano control-plane components (scheduler, controller-manager, webhook-manager).
+2. Provide a single-command workflow (`make dev-up`) that provisions a local Kind cluster with a container registry and deploys Volcano with live-reloading.
+3. Support multi-architecture development (amd64 and arm64) without manual configuration.
+4. Integrate unit tests and end-to-end tests as on-demand resources within the same development environment.
+5. Keep all development tooling self-contained in `_output/bin` to avoid polluting the host system.
+
+## Architecture Overview
+
+The workflow is built on three core tools:
+
+- **[Kind](https://kind.sigs.k8s.io/)** — Local Kubernetes cluster running in Docker containers.
+- **[ctlptl](https://github.com/tilt-dev/ctlptl)** — Declarative cluster lifecycle manager that provisions Kind clusters with an attached local container registry.
+- **[Tilt](https://tilt.dev/)** — Development environment that watches source files, builds container images, and live-updates running pods.
+
+```
+Developer workstation
++-------------------------------------------------------------------+
+|                                                                   |
+|  make dev-up                                                      |
+|    |                                                              |
+|    +-> dev-install-tilt    (download Tilt binary to _output/bin)  |
+|    +-> dev-install-kind    (download Kind binary to _output/bin)  |
+|    +-> dev-install-ctlptl  (download ctlptl binary to _output/bin)|
+|    +-> dev-create-kind-cluster  (ctlptl apply)                    |
+|    +-> tilt up                                                    |
+|                                                                   |
++-------------------------------------------------------------------+
+|                                                                   |
+|  Kind cluster: kind-volcano-dev                                   |
+|  +-------------------------------------------------------------+  |
+|  |  volcano-system namespace                                   |  |
+|  |  +------------------+  +------------------+                 |  |
+|  |  | vc-scheduler     |  | vc-controller-   |                 |  |
+|  |  | (live-reload)    |  | manager          |                 |  |
+|  |  +------------------+  | (live-reload)    |                 |  |
+|  |                        +------------------+                 |  |
+|  |  +------------------+  +------------------+                 |  |
+|  |  | vc-webhook-      |  | admission-init   |                 |  |
+|  |  | manager          |  | (Job)            |                 |  |
+|  |  | (live-reload)    |  +------------------+                 |  |
+|  |  +------------------+                                       |  |
+|  |                                                             |  |
+|  |  volcano-monitoring namespace                               |  |
+|  |  +------------------+  +-------+  +------------------+      |  |
+|  |  | prometheus       |  |grafana|  | kube-state-      |      |  |
+|  |  | (:3001)          |  |(:3000)|  | metrics          |      |  |
+|  |  +------------------+  +-------+  +------------------+      |  |
+|  +-------------------------------------------------------------+  |
+|                                                                   |
+|  Local registry: volcano-registry:5005                            |
++-------------------------------------------------------------------+
+```
+
+### Component Relationship
+
+1. **ctlptl** provisions a Kind cluster (`kind-volcano-dev`) with 1 control-plane node and 4 worker nodes, plus a local Docker registry (`volcano-registry:5005`).
+2. **Tilt** watches the Volcano source tree and uses `docker_build` with `live_update` to sync code changes into running containers.
+3. Inside each container, an **entrypoint.sh** script runs the Volcano binary as a child process. When Tilt syncs new files and touches `/tmp/reload`, the script stops the process, rebuilds the binary in-container, and restarts it.
+4. The Helm chart is rendered by Tilt's `helm()` function with development-specific value overrides (increased log verbosity, relaxed scheduling period, control-plane tolerations).
+
+## File Layout
+
+All Tilt-specific files live under `hack/tilt/`:
+
+```
+hack/tilt/
++-- Makefile                        # Make targets for dev lifecycle
++-- Tiltfile                        # Tilt orchestration (builds, deploys, resources)
++-- Dockerfile.tilt                 # Multi-stage Dockerfile for scheduler/controller/webhook
++-- Dockerfile.admission-init.tilt  # Lightweight Dockerfile for admission init Job
++-- entrypoint.sh                   # Live-reload entrypoint for Volcano binaries
++-- ctlptl-kind-registry.yaml       # ctlptl declarative config for Kind + registry
++-- values-tilt-override.yaml       # Helm value overrides for local development
+```
+
+The `hack/tilt/Makefile` is included by the root `Makefile`, exposing `dev-*` targets at the top level.
+
+## Detailed Design
+
+### Cluster Provisioning
+
+The cluster is managed declaratively through ctlptl. The configuration is composed at apply time from two files:
+
+1. `ctlptl-kind-registry.yaml` — defines the local Docker registry and the cluster identity:
+
+```yaml
+apiVersion: ctlptl.dev/v1alpha1
+kind: Registry
+name: volcano-registry
+port: 5005
+---
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: kind-volcano-dev
+product: kind
+registry: volcano-registry
+```
+
+2. `hack/e2e-kind-config.yaml` — the shared Kind cluster configuration (feature gates, containerd patches, node topology, kubeadm patches). This file is the single source of truth for Kind cluster settings, shared between the Tilt dev workflow and the e2e test workflow (`run-e2e-kind.sh`).
+
+At `make dev-create-kind-cluster` time, the Makefile merges these two files: it appends `e2e-kind-config.yaml` content (stripped of `kind:` and `apiVersion:` headers) under the `kindV1Alpha4Cluster:` key and pipes the result to `ctlptl apply -f -`. This ensures any Kind cluster config changes (e.g., new feature gates, node count, kubeadm patches) are automatically picked up by both workflows without duplication.
+
+ctlptl handles:
+- Creating the local Docker registry container.
+- Creating the Kind cluster with the registry pre-configured so that images pushed to `localhost:5005` are accessible inside the cluster.
+- Idempotent applies — running `ctlptl apply` when the cluster already exists is a no-op.
+
+### Image Building and Live-Reload
+
+Tilt builds four container images:
+
+| Image | Dockerfile | Live-reload | Purpose |
+|---|---|---|---|
+| `volcanosh/vc-scheduler` | `Dockerfile.tilt` | Yes | Batch scheduler |
+| `volcanosh/vc-controller-manager` | `Dockerfile.tilt` | Yes | Controller manager |
+| `volcanosh/vc-webhook-manager` | `Dockerfile.tilt` | Yes | Webhook admission controller |
+| `volcanosh/vc-admission-init` | `Dockerfile.admission-init.tilt` | No | One-shot TLS certificate init Job |
+
+The three main components share a single `Dockerfile.tilt` parameterized by `COMPONENT` build arg. The Dockerfile:
+
+1. Starts from `golang:1.25.0` (matching the project's Go version).
+2. Copies source code and runs `go mod download`.
+3. Builds the binary with `GOOS=linux GOARCH=${TARGETARCH}`.
+4. Uses `dumb-init` as PID 1 to forward signals correctly.
+5. Delegates to `entrypoint.sh` for runtime process management.
+
+The `live_update` configuration syncs `pkg/`, `cmd/<component>`, `third_party/`, and `entrypoint.sh` into the running container and touches `/tmp/reload` to trigger a rebuild.
+
+#### Live-Reload Mechanism
+
+The `entrypoint.sh` script implements a file-watch loop:
+
+```
+1. Build and start the Volcano binary as a background child process.
+2. Loop every 1 second:
+   a. Check if /tmp/reload exists.
+   b. If yes: stop child, rebuild binary (go build), start child, remove /tmp/reload.
+```
+
+The rebuild uses `GOARCH="$(go env GOARCH)"` to detect the container's architecture at runtime, supporting both amd64 and arm64 Kind clusters.
+
+### Multi-Architecture Support
+
+All download URLs and build commands use architecture-aware variables:
+
+- **Tilt and ctlptl downloads** (`hack/tilt/Makefile`): A `HOSTARCH` variable maps `uname -m` output to release archive naming (`x86_64` stays as-is, `aarch64` becomes `arm64`).
+- **Docker image builds** (`Dockerfile.tilt`): Uses `ARG TARGETARCH` (set automatically by Docker BuildKit) for cross-compilation.
+- **In-container rebuilds** (`entrypoint.sh`): Uses `go env GOARCH` to detect the runtime architecture.
+
+### Helm Integration
+
+Tilt renders the Volcano Helm chart using its built-in `helm()` function, combining:
+
+1. The default `values.yaml` from the chart.
+2. A `values-tilt-override.yaml` with development-specific settings:
+   - `image_pull_policy: IfNotPresent` (images come from the local registry).
+   - Scheduler and controller log verbosity at level 5.
+   - Scheduling period reduced to 1 second.
+   - Control-plane tolerations on all components (so pods can schedule on Kind's control-plane node if needed).
+
+### Resource Grouping
+
+Tilt resources are organized into labeled groups for the Tilt UI:
+
+- **volcano**: Core Volcano resources (namespaces, CRDs, admission, scheduler, controllers, roles).
+- **monitoring**: Prometheus, Grafana, kube-state-metrics.
+- **tests-install**: Manual install targets for test dependencies (KWOK, Ginkgo).
+- **tests**: Unit tests and per-suite e2e test triggers (all manual, on-demand).
+
+Resource dependencies ensure correct ordering:
+- `volcano-admission` depends on `volcano-namespaces`, `volcano-crds`, and `volcano-admission-init`.
+- `volcano-scheduler` and `volcano-controllers` depend on `volcano-namespaces`.
+
+### Testing Integration
+
+The Tiltfile registers test suites as `local_resource` entries with `trigger_mode=TRIGGER_MODE_MANUAL` and `auto_init=False`:
+
+- `unit-tests` - Runs `make unit-test`.
+- `e2e-tests-all` - Runs all e2e suites sequentially.
+- Individual suite targets: `e2e-tests-jobp`, `e2e-tests-jobseq`, `e2e-tests-schedulingbase`, `e2e-tests-schedulingaction`, `e2e-tests-vcctl`, `e2e-tests-dra`, `e2e-tests-hypernode`, `e2e-tests-cronjob`.
+- `e2e-tests-schedulingbase-focused-example` — A pre-configured single-test example (see [Focused Test Execution](#focused-test-execution) below).
+
+Test dependencies (KWOK, Ginkgo) are registered as separate manual install resources under the `tests-install` label. E2E test resources declare `resource_deps` on `install-ginkgo` (and `install-kwok` for `e2e-tests-all`), which means Tilt will block a triggered test from running until its dependencies have reached the Ready state. However, since the dependencies are also manual-trigger resources, they are **not** triggered automatically — the developer must trigger them explicitly on first use. Once a dependency has been triggered and reaches Ready, it stays Ready for the remainder of the Tilt session, so subsequent test runs only require triggering the test resource itself.
+
+The typical first-run workflow is:
+
+1. Trigger the test resource (e.g., `make dev-tilt-trigger RESOURCE=e2e-tests-schedulingbase`).
+2. The test enters `Pending` state because `install-ginkgo` is not yet Ready.
+3. Trigger the dependency (`make dev-tilt-trigger RESOURCE=install-ginkgo`).
+4. Once the dependency completes, the test unblocks and runs automatically.
+5. On subsequent runs, only step 1 is needed — the dependency is already Ready.
+
+#### E2E Test Runner Integration
+
+Running Ginkgo E2E tests during local development is traditionally cumbersome: the CI script `hack/run-e2e-kind.sh` handles cluster creation, KWOK setup, Volcano installation, and Ginkgo invocations as a single pipeline, making it unusable against an already-running Tilt cluster. Developers would otherwise need to construct manual `ginkgo` commands with the correct suite paths, `--focus`/`--skip` flags, and `KUBECONFIG` plumbing.
+
+The Tilt integration solves this through three mechanisms:
+
+**1. `run-ginkgo-suite()` — centralized Ginkgo invocation.**
+
+A function in `hack/run-e2e-kind.sh` centralizes all Ginkgo flag construction:
+
+```bash
+run-ginkgo-suite <suite_path> <default_focus> <default_skip> [ginkgo_flags...]
+```
+
+Every test suite (in both CI and Tilt) calls this function instead of invoking `ginkgo` directly. The function handles `--focus` and `--skip` flag assembly, ensuring consistent behavior across all execution contexts. Additional ginkgo flags (e.g., `--slow-spec-threshold`, `-p`) are passed through as variadic arguments.
+
+**2. `E2E_LOCAL_ONLY=1` — skip bootstrapping for Tilt-managed clusters.**
+
+When `E2E_LOCAL_ONLY=1` is set, `hack/run-e2e-kind.sh` skips:
+- Kind cluster creation (`kind-up-cluster`)
+- KWOK installation (`install-kwok-with-helm`)
+- Volcano Helm installation (`install-volcano`)
+- Ginkgo installation (`install-ginkgo-if-not-exist` — assumed pre-installed via Tilt's `install-ginkgo` resource)
+
+The script proceeds directly to running the requested test suite against the existing cluster. This reduces test invocation from minutes to seconds.
+
+**3. `E2E_FOCUS` and `E2E_SKIP` — runtime overrides for test selection.**
+
+Two environment variables override the per-suite default focus and skip patterns:
+
+```bash
+# Run only "Gang scheduling" tests, skipping sig-tagged and Full Occupied tests
+E2E_FOCUS="Gang scheduling" E2E_SKIP="\[sig-.*\]|Full Occupied" \
+  E2E_LOCAL_ONLY=1 E2E_TYPE=SCHEDULINGBASE hack/run-e2e-kind.sh
+```
+
+When `E2E_FOCUS` or `E2E_SKIP` is set, it takes precedence over the suite's hardcoded defaults. When unset, the defaults apply unchanged. This lets developers narrow test scope without editing any files.
+
+##### Focused test execution
+
+The Tiltfile includes a pre-configured example resource for running a single test:
+
+```
+e2e-tests-schedulingbase-focused-example
+  E2E_FOCUS = "Gang scheduling"    (default, overridable via env)
+  E2E_SKIP  = "\[sig-.*\]|Full Occupied"  (default, overridable via env)
+  Suite     = SCHEDULINGBASE
+```
+
+This resource demonstrates single-test execution within Tilt. Developers iterating on a specific feature can:
+
+1. **Copy this resource pattern** in the Tiltfile, changing the `E2E_FOCUS` default to match their test.
+2. **Override at runtime** by setting `E2E_FOCUS` and `E2E_SKIP` environment variables before starting Tilt (they are passed through to `hack/run-e2e-kind.sh`).
+3. **Trigger from the Tilt UI or CLI** — `make dev-tilt-trigger RESOURCE=e2e-tests-schedulingbase-focused-example` — getting results for a single test in seconds rather than waiting for the entire suite.
+
+This is particularly valuable for scheduler and controller development, where a full E2E suite run takes 10-30 minutes but a single focused test completes in under a minute.
+
+##### CI and Tilt alignment
+
+Both CI and Tilt call the same `hack/run-e2e-kind.sh` script with the same `run-ginkgo-suite()` function. The only difference is the environment:
+
+| Aspect | CI (`run-e2e-kind.sh`) | Tilt (`E2E_LOCAL_ONLY=1`) |
+|---|---|---|
+| Cluster creation | `kind-up-cluster` | Skipped (cluster exists) |
+| Volcano install | `install-volcano` | Skipped (Tilt manages it) |
+| Ginkgo install | `install-ginkgo-if-not-exist` | Skipped (Tilt `install-ginkgo` resource) |
+| Test invocation | `run-ginkgo-suite()` | `run-ginkgo-suite()` (identical) |
+| Focus/skip | Per-suite defaults | Defaults or `E2E_FOCUS`/`E2E_SKIP` overrides |
+
+This single-source-of-truth approach ensures that a test passing locally in Tilt will also pass in CI (and vice versa).
+
+### Version Management
+
+Tool versions follow a single-source-of-truth principle:
+
+| Tool | Version Variable | Defined In |
+|---|---|---|
+| Kind | `KIND_VERSION` | Root `Makefile` |
+| Tilt | `TILT_VERSION` | `hack/tilt/Makefile` |
+| ctlptl | `CTLPTL_VERSION` | `hack/tilt/Makefile` |
+
+The root `Makefile` already defines `KIND_VERSION` for CI usage. The Tilt Makefile requires it as a prerequisite (`ifndef KIND_VERSION ... $(error ...)`), ensuring consistency between CI and local development.
+
+## Usage
+
+### Quick Start
+
+```bash
+# Start the development environment (installs tools, creates cluster, starts Tilt)
+make dev-up
+
+# In another terminal, check resource status
+make dev-tilt-status
+
+# View logs for a specific component
+make dev-tilt-logs RESOURCE=volcano-scheduler
+
+# Wait for all resources to be ready
+make dev-wait-ready
+```
+
+### Development Workflow
+
+1. Run `make dev-up` to start Tilt.
+2. Edit any Go source file under `pkg/`, `cmd/`, or `third_party/`.
+3. Tilt automatically syncs the changed files into the running container.
+4. The entrypoint script detects the sync, rebuilds the binary, and restarts the process.
+5. Check logs in the Tilt UI (http://localhost:10350) or via `make dev-tilt-logs`.
+
+### Running Tests
+
+Test dependencies (`install-ginkgo`, `install-kwok`) must be triggered once per Tilt session before running e2e tests. After the first trigger they stay Ready for subsequent runs.
+
+```bash
+# First time: trigger test dependency installation (once per session)
+make dev-tilt-trigger RESOURCE=install-ginkgo
+
+# Run unit tests (no dependencies needed)
+make dev-tilt-trigger RESOURCE=unit-tests
+
+# Run a specific e2e suite
+make dev-tilt-trigger RESOURCE=e2e-tests-schedulingbase
+
+# If the test stays in Pending, trigger its dependency first
+# (install-ginkgo for most suites, install-kwok additionally for e2e-tests-all)
+
+# Run a focused single test (uses E2E_FOCUS/E2E_SKIP env vars)
+make dev-tilt-trigger RESOURCE=e2e-tests-schedulingbase-focused-example
+
+# Check test results
+make dev-tilt-logs RESOURCE=e2e-tests-schedulingbase
+```
+
+### Teardown
+
+```bash
+# Stop Tilt but keep the cluster
+make dev-down
+
+# Full cleanup: stop Tilt, delete cluster, remove tool binaries
+make dev-clean
+```
+
+### Available Make Targets
+
+| Target | Description |
+|---|---|
+| `dev-up` | Install tools, create cluster, start Tilt |
+| `dev-down` | Stop Tilt, leave cluster running |
+| `dev-clean` | Stop Tilt, delete cluster and registry, remove tool binaries |
+| `dev-status` | Show cluster and connection info |
+| `dev-tilt-status` | Show status of all Tilt-managed resources |
+| `dev-tilt-logs` | Show logs (all or `RESOURCE=<name>`) |
+| `dev-tilt-describe` | Describe a Tilt resource (`RESOURCE=<name>`) |
+| `dev-tilt-trigger` | Manually trigger a resource (`RESOURCE=<name>`) |
+| `dev-wait-ready` | Block until all resources reach Ready state |
+| `dev-install-kind` | Install Kind binary to `_output/bin` |
+| `dev-install-tilt` | Install Tilt binary to `_output/bin` |
+| `dev-install-ctlptl` | Install ctlptl binary to `_output/bin` |
+| `dev-create-kind-cluster` | Create Kind cluster and registry via ctlptl |
+| `dev-delete-kind-cluster` | Delete Kind cluster and registry |
+
+## Design Decisions
+
+### Why Kind over k3d
+
+Kind (Kubernetes IN Docker) was chosen over k3d for the following reasons:
+
+- Kind is the de facto standard for local Kubernetes development in the Kubernetes ecosystem.
+- Volcano's CI already uses Kind for e2e testing, ensuring parity between local development and CI.
+- Kind uses `kubeadm`-bootstrapped clusters with unmodified upstream Kubernetes, giving higher fidelity for testing scheduler behavior.
+- k3d uses k3s (a trimmed-down distribution) which may mask issues related to full Kubernetes API behavior.
+
+### Why ctlptl over raw Kind commands
+
+ctlptl provides declarative cluster management with built-in local registry support:
+
+- A single YAML file defines both the cluster and its registry, replacing multi-step imperative setup scripts.
+- Idempotent operations: `ctlptl apply` only creates resources that do not already exist.
+- Registry wiring is automatic — ctlptl configures Kind nodes to trust the local registry without manual containerd config patches.
+- Cascade deletion (`--cascade=true`) ensures clean teardown of both cluster and registry.
+
+### Why Tilt over Skaffold and Other Tools
+
+Several tools exist for Kubernetes-native development workflows. This section compares
+the options considered and explains why Tilt is the best fit for Volcano.
+
+#### Comparison Matrix
+
+| Capability | [Tilt](https://tilt.dev/) | [Skaffold](https://skaffold.dev/) | [DevSpace](https://devspace.sh/) | [Telepresence](https://www.telepresence.io/) |
+|---|---|---|---|---|
+| File-level live sync into running containers | Yes (`live_update`) | Partial (`sync` in v2, limited) | Yes (`sync`) | N/A (intercept-based) |
+| In-container rebuild on sync | Yes (via custom entrypoint) | No (rebuilds image or restarts pod) | Yes (via hooks) | N/A |
+| Native Helm chart rendering | Yes (`helm()` built-in) | Yes (`helm` deployer) | Yes (helm integration) | No |
+| Resource dependency DAG | Yes (explicit `resource_deps`) | No | No | No |
+| Web UI with live status | Yes (built-in at :10350) | No (CLI only) | Yes (optional UI) | No |
+| Manual-trigger resources | Yes (`TRIGGER_MODE_MANUAL`) | No | No | No |
+| Context safety guard | Yes (`allow_k8s_contexts`) | Yes (`kubeContext`) | Yes (`vars.DEVSPACE_CONTEXT`) | Partial |
+| Starlark scripting | Yes (full Starlark) | No (YAML only) | No (YAML + hooks) | No |
+| Active maintenance (2025) | Yes | Maintenance mode | Yes | Yes |
+
+#### Why Tilt wins for Volcano
+
+**1. File-granularity live sync without image rebuilds.**
+Volcano's Go source tree is large (~500k+ lines across `pkg/`, `cmd/`, `staging/`).
+A full Docker image rebuild on every change takes 30-90 seconds even with layer caching.
+Tilt's `live_update` syncs only the changed `.go` files into the running container and
+triggers an in-container `go build`, bringing incremental feedback down to 5-15 seconds.
+Skaffold's sync support is limited to interpreted languages (Python, Node.js) — it
+cannot trigger a recompilation step after syncing Go source files, so it falls back to
+full image rebuilds for compiled languages.
+
+**2. Resource dependency DAG matches Volcano's deployment ordering.**
+Volcano has strict deployment dependencies: CRDs must exist before admission webhooks
+register, the admission-init Job must complete before the admission deployment starts,
+and namespaces must exist before anything else. Tilt's `resource_deps` models this
+DAG explicitly. Skaffold deploys manifests in a flat sequence and has no built-in
+dependency mechanism, requiring workarounds like init containers or manual ordering.
+
+**3. Manual-trigger test resources.**
+The Tiltfile registers unit tests and eight separate e2e test suites as on-demand
+resources. Developers can trigger them from the Tilt UI or CLI without leaving the
+development loop. Skaffold has no concept of manual-trigger resources — everything
+in the pipeline runs automatically or not at all.
+
+**4. Starlark scripting for complex orchestration.**
+The Tiltfile uses Starlark (a Python-like language) to loop over components, share
+Dockerfiles via build args, conditionally include monitoring resources, and compose
+Helm values. Skaffold's YAML-only configuration requires verbose repetition for
+parameterized builds and cannot express conditional logic.
+
+**5. Skaffold's uncertain future.**
+Google announced in late 2023 that Skaffold is in maintenance mode. While it remains
+functional, new feature development has stopped. Tilt continues active development
+under Docker, Inc.
+
+#### Why not DevSpace?
+
+DevSpace offers comparable sync and in-container build capabilities. However:
+
+- DevSpace lacks a resource dependency DAG, which Volcano's deployment ordering requires.
+- DevSpace's Helm integration is functional but less mature than Tilt's native `helm()` function, which handles value layering and set overrides naturally.
+- DevSpace's configuration format (devspace.yaml) is less expressive than Starlark for looping over multiple components with shared build logic.
+- Tilt has stronger adoption in the Kubernetes ecosystem (used by Cluster API, Crossplane, Cilium, and similar infrastructure projects), providing better community support and proven patterns for controller/operator development.
+
+#### Why not Telepresence?
+
+Telepresence takes a fundamentally different approach: instead of syncing code into
+cluster containers, it intercepts traffic from the cluster and routes it to a locally
+running process. This is powerful for debugging a single service but is a poor fit
+for Volcano because:
+
+- Volcano has three tightly coupled control-plane components (scheduler, controller-manager, webhook-manager) that need to run simultaneously. Telepresence intercepts work per-service, not per-cluster.
+- Scheduler behavior depends on cluster state (nodes, pods, queues) that is difficult to replicate locally outside the cluster.
+- The webhook-manager requires in-cluster TLS certificates generated by the admission-init Job, which cannot work with a local process.
+
+### Why Tilt is ideal for Volcano specifically
+
+Beyond the general tool comparison, Tilt aligns with Volcano's development model
+in ways that are specific to Kubernetes scheduler/controller projects:
+
+- **Multi-component coordination.** Volcano is not a single binary — it is three cooperating control-plane processes plus an admission init Job. Tilt's resource model treats each as a first-class resource with health checks, logs, and dependency ordering, giving developers visibility into the full system rather than one component at a time.
+- **Scheduler testing requires real cluster state.** Volcano's scheduler makes decisions based on node resources, pod groups, queue configurations, and CRD state. Unlike a web application where you can mock backends, meaningful scheduler development requires a running cluster with actual Kubernetes objects. Tilt's Kind integration provides this with zero manual setup.
+- **Helm chart is the source of truth.** Volcano is deployed via Helm in production. By rendering the same Helm chart for local development (with override values), Tilt ensures that template changes, RBAC rules, and ConfigMap updates are tested in the development loop rather than discovered at deploy time.
+- **CI parity.** Volcano's CI already uses Kind clusters. Tilt reuses the same Kind version and cluster configuration, so issues caught locally reproduce in CI and vice versa.
+
+### Why in-container builds
+
+The `Dockerfile.tilt` runs builds inside the container rather than on the host:
+
+- Eliminates the need for a local Go toolchain on the developer's machine.
+- Ensures the build environment matches the container's OS and architecture exactly.
+- `go mod download` is cached in the Docker layer, so only changed source files trigger recompilation.
+- Live-update syncs source files and triggers `go build` inside the container, achieving sub-minute rebuild times for incremental changes.
+
+## Limitations and Future Work
+
+- **Linux-only tool downloads**: The Makefile downloads Linux-specific Tilt and ctlptl binaries. macOS and Windows developers would need to install these tools separately or extend the download logic.
+- **No GPU support**: The Kind cluster does not configure GPU passthrough. GPU-dependent scheduling features cannot be tested locally.
+- **Single cluster topology**: The current setup uses a fixed 1 control-plane + 4 worker node topology. A future enhancement could make node count configurable.
+- **No agent-scheduler or vc-agent support**: Only the three core control-plane components are included. Adding agent-scheduler and vc-agent images would extend coverage to the full Volcano stack.
+
+### Agentic Development Workflows
+
+The Tilt-based workflow has an additional benefit for AI coding agent workflows.
+When AI agents assist with Volcano development, the development environment's
+safety boundaries become critical.
+
+#### The kubectl and Helm risk for agents
+
+AI coding agents that interact with Kubernetes clusters directly via `kubectl` and
+`helm` face significant risks:
+
+- **Destructive operations.** A single `kubectl delete` or `helm uninstall` can destroy
+  cluster state. An agent that misinterprets a prompt could delete CRDs, wipe namespaces,
+  or uninstall the system it is developing against.
+- **Stateful side effects.** Unlike file edits (which can be reverted via `git checkout`),
+  cluster mutations are stateful and often irreversible. Deleted PersistentVolumeClaims,
+  evicted pods, and removed finalizers cannot be undone.
+- **Credential exposure.** Agents with `kubectl` access inherit the user's kubeconfig,
+  which may contain credentials for production clusters. A context switch error could
+  direct destructive commands at the wrong cluster.
+- **Unbounded blast radius.** `kubectl apply -f` on a malformed manifest, `helm upgrade`
+  with incorrect values, or `kubectl patch` with a bad JSON path can cascade into
+  cluster-wide failures.
+
+#### How Tilt mitigates these risks
+
+The Tilt-based workflow provides a safety layer that makes agent-assisted development
+viable:
+
+- **`allow_k8s_contexts` as a hard guard.** The Tiltfile explicitly lists allowed
+  Kubernetes contexts (`kind-volcano-dev`). Tilt refuses to operate against any other
+  context, making it impossible to accidentally target a production cluster.
+- **Declarative-only mutations.** All cluster changes flow through Tilt's declarative
+  resource model. There is no need for agents to run `kubectl apply` or `helm install`
+  directly — Tilt handles deployment as a side effect of source file changes.
+- **Make targets as the agent interface.** Agents interact with the development
+  environment through Make targets (`dev-up`, `dev-down`, `dev-tilt-status`,
+  `dev-tilt-logs`), which are safe, idempotent, and well-scoped. This eliminates
+  the need to grant agents direct `kubectl` or `helm` access.
+- **Reproducible teardown.** If an agent corrupts the cluster state, `make dev-clean`
+  destroys the entire Kind cluster and registry, and `make dev-up` recreates it from
+  scratch in minutes. The blast radius is bounded to a disposable local cluster.
+- **Source-driven feedback loop.** Agents edit Go source files, Tilt syncs and rebuilds.
+  The agent never needs to reason about Kubernetes resource lifecycles, manifest
+  ordering, or Helm release state. The complexity is encapsulated in the Tiltfile.
+
+This design means an AI coding agent can safely develop Volcano components by editing
+source files and reading logs, without ever needing cluster-admin privileges or direct
+access to Kubernetes APIs.

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -1,5 +1,6 @@
 This document helps you get started using the Volcano code base. If you follow this guide and find a problem, please take a few minutes to update this file.
 
+- [Tilt-based local development](#tilt-based-local-development)
 - [Building the code](#building-the-code)
 - [Building docker images](#building-docker-images)
 - [Building a specific docker image](#building-a-specific-docker-image)
@@ -164,4 +165,145 @@ Before sending pull requests, you should at least make sure your changes have pa
 - The preferred method of testing multiple scenarios or input is [table-driven testing](https://go.dev/wiki/TableDrivenTests).
 - Concurrent unit test runs must pass.
 
+## Tilt-Based Local Development
+
+For iterative development with live-reloading, Volcano provides a Tilt-based workflow
+that eliminates the manual build-push-deploy cycle. One command sets up everything:
+
+```bash
+make dev-up
+```
+
+This installs Kind, Tilt, and ctlptl into `_output/bin`, creates a local Kind cluster
+with a Docker registry, deploys Volcano via Helm, and starts Tilt for live-reloading.
+No local Go toolchain is required — all builds happen inside containers.
+
+After `dev-up` completes, edit any Go source file under `pkg/`, `cmd/`, or
+`third_party/`. Tilt syncs the changes into the running container and the entrypoint
+script rebuilds the binary and restarts the process automatically.
+
+
+### Tips and Best Practices
+
+**First-run startup time.** The initial `make dev-up` takes roughly 20-25 minutes
+because Docker builds the Go compiler image layers and compiles all Volcano binaries
+from scratch. The next builds will be somewhat faster due to the cached layers.
+
+**Avoid unnecessary image rebuilds across branches.** Tilt rebuilds container images
+whenever the tracked source files differs from the last build **at startup**. If you switch branches
+frequently, you can avoid long rebuilds by keeping the cluster and Tilt running on
+your base branch (e.g. `master`) and only switching branches _after_ the initial
+build completes:
+
+1. Start from a clean state on your base branch:
+   ```bash
+   git checkout master
+   make dev-up          # builds images and caches layers
+   ```
+2. Switch to your feature branch while Tilt is running:
+   ```bash
+   git checkout my-feature-branch
+   ```
+3. Tilt detects the changed files and performs an incremental live-update (syncing
+   only the changed sources into the running container) instead of a full image
+   rebuild. This brings branch-switch turnaround down to seconds.
+4. After you finished the work save it and bring down the tilt environment.
+   ```bash
+   git commit -m "Let's save this work"
+   make dev-down
+   ```
+5. **BEFORE** you continue the work go back to master.
+   If you stay on the `my-feature-branch` tilt will do a full ~20-25 minute rebuild.
+   ```bash
+   git checkout master
+   make dev-up
+   ```
+6. Go back to feature branch if tilt is running. (no rebuild)
+   ```bash
+   git checkout my-feature-branch
+   ```
+
+**Keep `dev-down` vs `dev-clean` straight.** Use `make dev-down` to stop Tilt while
+keeping the Kind cluster alive — this lets you inspect the cluster with `kubectl`
+and restart Tilt later without re-creating the cluster. Use `make dev-clean` only
+when you want a full teardown.
+
+### Viewing Status and Logs
+
+```bash
+# Open the Tilt web UI
+# (automatically available at http://localhost:10350 after dev-up)
+
+# Check resource status from the terminal
+make dev-tilt-status
+
+# View logs for a specific component
+make dev-tilt-logs RESOURCE=volcano-scheduler
+
+# Describe a resource in detail
+make dev-tilt-describe RESOURCE=volcano-scheduler
+
+# Wait until all resources are ready
+make dev-wait-ready
+```
+
+### Running Tests via Tilt
+
+Test resources are registered in Tilt with manual triggers so they do not run
+automatically. Test dependencies (`install-ginkgo`, `install-kwok`) must be
+triggered once per Tilt session — after the first trigger they stay Ready for all
+subsequent test runs.
+
+```bash
+# First time only: install test dependencies (once per Tilt session)
+make dev-tilt-trigger RESOURCE=install-ginkgo
+# install-kwok is additionally needed for e2e-tests-all
+
+# Run unit tests (no dependencies needed)
+make dev-tilt-trigger RESOURCE=unit-tests
+
+# Run a specific e2e suite
+make dev-tilt-trigger RESOURCE=e2e-tests-schedulingbase
+
+# If the test stays in Pending state, its dependency (install-ginkgo) has
+# not been triggered yet — trigger it and the test will unblock automatically
+
+# Run a focused single test
+make dev-tilt-trigger RESOURCE=e2e-tests-schedulingbase-focused-example
+
+# Check test output
+make dev-tilt-logs RESOURCE=e2e-tests-schedulingbase
+```
+
+### Teardown
+
+```bash
+# Stop Tilt but keep the Kind cluster running (for manual kubectl inspection)
+make dev-down
+
+# Full cleanup: stop Tilt, delete cluster and registry, remove tool binaries
+make dev-clean
+```
+
+### All Development Targets
+
+| Target | Description |
+|---|---|
+| `dev-up` | Install tools, create cluster, start Tilt |
+| `dev-down` | Stop Tilt, leave cluster running |
+| `dev-clean` | Stop Tilt, delete cluster and registry, remove tool binaries |
+| `dev-status` | Show cluster and connection info |
+| `dev-tilt-status` | Show status of all Tilt-managed resources |
+| `dev-tilt-logs` | Show logs (all or `RESOURCE=<name>`) |
+| `dev-tilt-describe` | Describe a Tilt resource (`RESOURCE=<name>`) |
+| `dev-tilt-trigger` | Manually trigger a resource (`RESOURCE=<name>`) |
+| `dev-wait-ready` | Block until all resources reach Ready state |
+| `dev-install-kind` | Install Kind binary to `_output/bin` |
+| `dev-install-tilt` | Install Tilt binary to `_output/bin` |
+| `dev-install-ctlptl` | Install ctlptl binary to `_output/bin` |
+| `dev-create-kind-cluster` | Create Kind cluster and registry via ctlptl |
+| `dev-delete-kind-cluster` | Delete Kind cluster and registry |
+
+For design rationale and architecture details, see the
+[Tilt-based development design proposal](../design/tilt-based-development.md).
 

--- a/docs/development/prepare-for-development.md
+++ b/docs/development/prepare-for-development.md
@@ -5,11 +5,45 @@ a few minutes to update this file.
 Volcano components only have few external dependencies you
 need to set up before being able to build and run the code.
 
+- [Quick Start with Tilt (Recommended)](#quick-start-with-tilt-recommended)
 - [Setting up Go](#setting-up-go)
 - [Setting up Docker](#setting-up-docker)
 - [Setting up Kubernetes](#setting-up-kubernetes)
 - [Setting up a personal access token](#setting-up-a-personal-access-token)
 - [What's next?](#whats-next)
+
+
+## Quick Start with Tilt (Recommended)
+
+The fastest way to get a full Volcano development environment running is with the
+Tilt-based workflow. It provisions a Kind cluster with a local registry and deploys
+all Volcano components with live-reload — a single command gets you from zero to a
+running cluster:
+
+```bash
+make dev-up
+```
+
+This installs Kind, Tilt, and ctlptl into `_output/bin` (no system-wide installs),
+creates a 5-node Kind cluster with a local Docker registry, deploys Volcano via Helm,
+and starts Tilt for live-reloading. Edit any Go file and the running component rebuilds
+automatically inside the container.
+
+**Prerequisites:** Docker and Make. No local Go toolchain is required for building
+and running Volcano — builds happen inside containers. However, installing Go locally
+is recommended for running unit tests, using code analysis tools, and working with
+the project long-term. See [Setting up Go](#setting-up-go) below.
+
+**Note:** The first run takes approximately 20-25 minutes while Docker builds all
+Go images from scratch. Subsequent runs are much faster thanks to layer caching.
+See the [Tips and Best Practices](./development.md#tips-and-best-practices) section
+for ways to speed up branch-switching workflows.
+
+For the full workflow reference (teardown, logs, tests, status), see the
+[Tilt-based development section](./development.md#tilt-based-local-development) in the
+development guide. For architecture and design rationale, see the
+[design proposal](../design/tilt-based-development.md).
+
 
 ## Setting up Go
 
@@ -18,7 +52,11 @@ To build, you'll need a Go development environment. If you haven't set up a Go d
 environment, please follow [these instructions](https://golang.org/doc/install)
 to install the Go tools.
 
-Volcano currently builds with Go 1.14
+The required go version can be tracked down from the Dockerfiles, search for "golang:" from the root:
+
+```
+grep -rh 'golang:' installer/dockerfile/ --include='Dockerfile*' | grep -oP 'golang:\K[0-9]+\.[0-9]+\.[0-9]+' | tail -1
+```
 
 ## Setting up Docker
 

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -15,11 +15,26 @@
 # limitations under the License.
 
 # spin up cluster with kind command
-function kind-up-cluster {
+function kind-create-cluster {
+  local kind_cmd=${KIND_BIN:-kind}
+
   check-kind
 
-  echo "Running kind: [kind create cluster ${CLUSTER_CONTEXT[*]} ${KIND_OPT}]"
-  kind create cluster "${CLUSTER_CONTEXT[@]}" ${KIND_OPT}
+  local cluster_name=${CLUSTER_CONTEXT[1]}
+
+  if ${kind_cmd} get clusters 2>/dev/null | grep -qw "${cluster_name}"; then
+    echo "Kind cluster ${cluster_name} already exists"
+  else
+    echo "Running kind: [${kind_cmd} create cluster ${CLUSTER_CONTEXT[*]} ${KIND_OPT}]"
+    ${kind_cmd} create cluster "${CLUSTER_CONTEXT[@]}" ${KIND_OPT}
+  fi
+
+  echo "Exporting kubeconfig for kind cluster ${cluster_name}"
+  ${kind_cmd} export kubeconfig --name "${cluster_name}" >/dev/null
+}
+
+function kind-up-cluster {
+  kind-create-cluster
 
   echo
   check-images
@@ -27,11 +42,11 @@ function kind-up-cluster {
   echo
   echo "Loading docker images into kind cluster"
   # only need to load images into control-plane node because volcano components are deployed on control-plane node.
-  kind load docker-image ${IMAGE_PREFIX}/vc-controller-manager:${TAG} "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
-  kind load docker-image ${IMAGE_PREFIX}/vc-scheduler:${TAG}          "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
-  kind load docker-image ${IMAGE_PREFIX}/vc-webhook-manager:${TAG}    "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+  ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-controller-manager:${TAG} "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+  ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-scheduler:${TAG}          "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+  ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-webhook-manager:${TAG}    "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
   if [[ "${E2E_TYPE}" == "AGENTSCHEDULER" ]]; then
-    kind load docker-image ${IMAGE_PREFIX}/vc-agent-scheduler:${TAG} "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
+    ${KIND_BIN:-kind} load docker-image ${IMAGE_PREFIX}/vc-agent-scheduler:${TAG} "${CLUSTER_CONTEXT[@]}" --nodes ${CLUSTER_CONTEXT[1]}-control-plane
   fi
 }
 
@@ -76,13 +91,51 @@ function check-prerequisites {
 
 # check if kind installed
 function check-kind {
+  local kind_cmd=${KIND_BIN:-kind}
+  local required_version=${KIND_VERSION}
+
+  # If KIND_VERSION is not set, try to resolve it from Makefile in VK_ROOT
+  if [[ -z "${required_version}" ]] && [[ -n "${VK_ROOT}" ]] && [[ -f "${VK_ROOT}/Makefile" ]]; then
+    required_version=$(make -s -C "${VK_ROOT}" print-kind-version 2>/dev/null)
+  fi
+
+  if [[ -z "${required_version}" ]]; then
+    echo "ERROR: KIND_VERSION is not set and could not be resolved from Makefile"
+    return 1
+  fi
+
   echo "Checking kind"
-  which kind >/dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    echo "Installing kind ..."
-    GOOS=${OS} go install sigs.k8s.io/kind@v0.31.0
+  if command -v "${kind_cmd}" >/dev/null 2>&1; then
+    local found_version
+    found_version=$("${kind_cmd}" version | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    if [[ "${found_version}" == "${required_version}" ]]; then
+      echo "Found kind at ${kind_cmd}, version: ${found_version}"
+      return
+    fi
+
+    echo "Kind version mismatch at ${kind_cmd} (found ${found_version}, required ${required_version})"
   else
-    echo -n "Found kind, version: " && kind version
+    echo "Kind not found at ${kind_cmd}"
+  fi
+
+  if [[ -n "${KIND_BIN}" ]]; then
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+    case "${arch}" in
+      x86_64) arch=amd64 ;;
+      aarch64|arm64) arch=arm64 ;;
+    esac
+
+    echo "Installing kind ${required_version} to ${KIND_BIN} ..."
+    mkdir -p "$(dirname "${KIND_BIN}")"
+    curl -fsSL "https://github.com/kubernetes-sigs/kind/releases/download/${required_version}/kind-${os}-${arch}" -o "${KIND_BIN}"
+    chmod +x "${KIND_BIN}"
+    echo "Installed kind at ${KIND_BIN}"
+  else
+    echo "Installing kind ${required_version} via go install ..."
+    GOOS=${OS} go install sigs.k8s.io/kind@${required_version}
+    echo -n "Installed kind, version: " && kind version
   fi
 }
 

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -24,6 +24,9 @@ export LOG_LEVEL=3
 export CLEANUP_CLUSTER=${CLEANUP_CLUSTER:-1}
 export E2E_TYPE=${E2E_TYPE:-"ALL"}
 export ARTIFACTS_PATH=${ARTIFACTS_PATH:-"${VK_ROOT}/volcano-e2e-logs"}
+export E2E_LOCAL_ONLY=${E2E_LOCAL_ONLY:-0}
+export E2E_FOCUS=${E2E_FOCUS:-""}
+export E2E_SKIP=${E2E_SKIP:-""}
 mkdir -p "$ARTIFACTS_PATH"
 
 NAMESPACE=${NAMESPACE:-volcano-system}
@@ -318,6 +321,27 @@ function uninstall-volcano {
   helm uninstall "${CLUSTER_NAME}" -n ${NAMESPACE}
 }
 
+function run-ginkgo-suite() {
+  local suite_path=$1
+  local default_focus=$2
+  local default_skip=$3
+  shift 3
+
+  local focus=${E2E_FOCUS:-${default_focus}}
+  local skip=${E2E_SKIP:-${default_skip}}
+
+  local cmd=(ginkgo "$@")
+  if [[ -n "${focus}" ]]; then
+    cmd+=(--focus="${focus}")
+  fi
+  if [[ -n "${skip}" ]]; then
+    cmd+=(--skip="${skip}")
+  fi
+  cmd+=("${suite_path}")
+
+  KUBECONFIG=${KUBECONFIG} GOOS=${OS} "${cmd[@]}"
+}
+
 function generate-log {
     echo "Generating volcano log files"
     kind export logs "${CLUSTER_CONTEXT[@]}" "$ARTIFACTS_PATH"
@@ -348,57 +372,63 @@ Disable displaying volcano component logs:
   exit 0
 fi
 
-if [[ $CLEANUP_CLUSTER -eq 1 ]]; then
+if [[ $CLEANUP_CLUSTER -eq 1 ]] && [[ ${E2E_LOCAL_ONLY} -ne 1 ]]; then
     trap cleanup EXIT
 fi
 
 source "${VK_ROOT}/hack/lib/install.sh"
 
-check-prerequisites
-kind-up-cluster
-install-kwok-with-helm
+if [[ ${E2E_LOCAL_ONLY} -ne 1 ]]; then
+    check-prerequisites
+    kind-up-cluster
+    install-kwok-with-helm
 
-if [[ -z ${KUBECONFIG+x} ]]; then
-    export KUBECONFIG="${HOME}/.kube/config"
+    if [[ -z ${KUBECONFIG+x} ]]; then
+        export KUBECONFIG="${HOME}/.kube/config"
+    fi
+
+    install-volcano
+else
+    if [[ -z ${KUBECONFIG+x} ]]; then
+        export KUBECONFIG="${HOME}/.kube/config"
+    fi
 fi
-
-install-volcano
 
 # Run e2e test
 cd ${VK_ROOT}
 
-install-ginkgo-if-not-exist
+if [[ ${E2E_LOCAL_ONLY} -ne 1 ]]; then
+    install-ginkgo-if-not-exist
+fi
 
 case ${E2E_TYPE} in
 "ALL")
     echo "Running e2e..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ./test/e2e/jobp/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/jobseq/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingbase/
-    # k8s 1.35 init will import its e2e suite, these k8s's suites need to skip
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --skip="\[sig-.*\]" --slow-spec-threshold='30s' --progress ./test/e2e/schedulingaction/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/cronjob/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress --focus="DRA E2E Test" ./test/e2e/dra/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/admission/
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/hypernode/
+    run-ginkgo-suite ./test/e2e/jobp/ "" "" -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/jobseq/ "" "" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/schedulingbase/ "" "" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/schedulingaction/ "" "\[sig-.*\]" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/vcctl/ "" "" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/cronjob/ "" "" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/dra/ "DRA E2E Test" "" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/admission/ "" "" -r --slow-spec-threshold='30s' --progress
+    run-ginkgo-suite ./test/e2e/hypernode/ "" "" -r --slow-spec-threshold='30s' --progress
     ;;
 "JOBP")
     echo "Running parallel job e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ./test/e2e/jobp/
+    run-ginkgo-suite ./test/e2e/jobp/ "" "" -v -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress
     ;;
 "JOBSEQ")
     echo "Running sequence job e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/jobseq/
+    run-ginkgo-suite ./test/e2e/jobseq/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "SCHEDULINGBASE")
     echo "Running scheduling base e2e suite...(need skip k8s framework's suites)"
-    # k8s 1.35 init will import its e2e suite, these k8s's suites need to skip
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --skip="\[sig-.*\]" --slow-spec-threshold='30s' --progress ./test/e2e/schedulingbase/
+    run-ginkgo-suite ./test/e2e/schedulingbase/ "" "\[sig-.*\]" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "SCHEDULINGACTION")
     echo "Running scheduling action e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingaction/
+    run-ginkgo-suite ./test/e2e/schedulingaction/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "SCHEDULINGGATES")
     echo "Running scheduling gates e2e suite..."
@@ -406,33 +436,33 @@ case ${E2E_TYPE} in
     ;;
 "VCCTL")
     echo "Running vcctl e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
+    run-ginkgo-suite ./test/e2e/vcctl/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "STRESS")
     echo "Running stress e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/stress/
+    run-ginkgo-suite ./test/e2e/stress/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "DRA")
     echo "Running dra e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress --focus="DRA E2E Test" ./test/e2e/dra/
+    run-ginkgo-suite ./test/e2e/dra/ "DRA E2E Test" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "ADMISSION_POLICY")
     echo "Running admission policy e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/admission/
+    run-ginkgo-suite ./test/e2e/admission/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "ADMISSION_WEBHOOK")
     echo "Running admission webhook e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/admission/
+    run-ginkgo-suite ./test/e2e/admission/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "HYPERNODE")
     echo "Creating 8 kwok nodes for 3-tier topology"
     install-kwok-nodes 8
     echo "Running hypernode e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/hypernode/
+    run-ginkgo-suite ./test/e2e/hypernode/ "" "" -r --slow-spec-threshold='30s' --progress
     ;;
-"CRONJOB")
-    echo "Running cronjob e2e suite..."
-    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/cronjob/
+"CRONJOB")  
+    echo "Running cronjob e2e suite..."  
+    run-ginkgo-suite ./test/e2e/cronjob/ "" "" -v -r --slow-spec-threshold='30s' --progress
     ;;
 "AGENTSCHEDULER")
     echo "Running agent scheduler e2e suite..."

--- a/hack/tilt/Dockerfile.admission-init.tilt
+++ b/hack/tilt/Dockerfile.admission-init.tilt
@@ -1,0 +1,29 @@
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:latest
+ARG KUBE_VERSION="1.35.0"
+ARG TARGETARCH
+ARG APK_MIRROR
+RUN if [ -n "$APK_MIRROR" ]; then sed -i "s@https://dl-cdn.alpinelinux.org@${APK_MIRROR}@g" /etc/apk/repositories ; fi && \
+    apk add --update ca-certificates && \
+    apk add --update openssl && \
+    apk add --update -t deps curl && \
+    curl -L https://dl.k8s.io/release/v$KUBE_VERSION/bin/linux/$TARGETARCH/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    apk del --purge deps && \
+    rm /var/cache/apk/*
+
+ADD installer/dockerfile/webhook-manager/gen-admission-secret.sh /gen-admission-secret.sh
+ENTRYPOINT ["/gen-admission-secret.sh"]

--- a/hack/tilt/Dockerfile.tilt
+++ b/hack/tilt/Dockerfile.tilt
@@ -1,0 +1,44 @@
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.25.0
+
+ARG TARGETARCH
+ARG COMPONENT
+ENV COMPONENT=${COMPONENT}
+ENV VOLCANO_HOME=/go/src/volcano.sh/volcano
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates openssl curl dumb-init less && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${VOLCANO_HOME}
+COPY go.mod go.sum ./
+# Copy staging directory before go mod download since go.mod has replace directive
+COPY staging/ ./staging/
+RUN go mod download
+
+COPY pkg/ ./pkg/
+COPY third_party/ ./third_party/
+COPY cmd/ ./cmd/
+COPY hack/tilt/entrypoint.sh ${VOLCANO_HOME}/entrypoint.sh
+
+RUN chmod +x ${VOLCANO_HOME}/entrypoint.sh
+RUN chown -R 1000:1000 ${VOLCANO_HOME}
+RUN useradd -u 1000 -m developer
+USER developer
+
+RUN GOOS=linux GOARCH=${TARGETARCH} go build -o ${VOLCANO_HOME}/vc-${COMPONENT} ./cmd/${COMPONENT}
+
+ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--", "/go/src/volcano.sh/volcano/entrypoint.sh"]

--- a/hack/tilt/Makefile
+++ b/hack/tilt/Makefile
@@ -1,0 +1,157 @@
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Makefile expects the following variables to be defined by the parent/root Makefile:
+# OUTPUT_DIR, BIN_DIR
+ifndef OUTPUT_DIR
+$(error OUTPUT_DIR is not set. Please define it in the parent Makefile.)
+endif
+
+ifndef BIN_DIR
+$(error BIN_DIR is not set. Please define it in the parent Makefile.)
+endif
+
+
+# Map host CPU to release archive naming: aarch64 becomes arm64 to match
+# upstream tarball names. x86_64 is intentionally kept as-is because Tilt
+# and ctlptl archives use "linux.x86_64" (not "amd64") in their filenames.
+HOSTARCH := $(shell uname -m)
+ifeq ($(HOSTARCH),aarch64)
+HOSTARCH := arm64
+endif
+
+TILT_VERSION=0.36.3
+CTLPTL_VERSION ?= 0.9.0
+TILT_BIN=${BIN_DIR}/tilt
+KIND_BIN=${BIN_DIR}/kind
+CTLPTL_BIN=${BIN_DIR}/ctlptl
+
+ifndef KIND_VERSION
+$(error KIND_VERSION is not set. Please define it in the parent Makefile.)
+endif
+
+KIND_CLUSTER_NAME ?= kind-volcano-dev
+KIND_CONTEXT_NAME ?= ${KIND_CLUSTER_NAME}
+CTLPTL_CONFIG ?= hack/tilt/ctlptl-kind-registry.yaml
+KIND_CONFIG ?= hack/e2e-kind-config.yaml
+
+TILT_WAIT_TIMEOUT ?= 10m
+TILT_WAIT_RESOURCES ?= \
+	uiresource/volcano-namespaces \
+	uiresource/volcano-crds \
+	uiresource/volcano-vcjob-roles \
+	uiresource/volcano-admission-init \
+	uiresource/volcano-admission \
+	uiresource/volcano-scheduler \
+	uiresource/volcano-controllers \
+	uiresource/prometheus-deployment \
+	uiresource/kube-state-metrics \
+	uiresource/grafana
+
+# Install Kind if not present in _output/bin or wrong version
+dev-install-kind:
+	@PATH="${BIN_DIR}:$$PATH" KIND_BIN="${KIND_BIN}" KIND_VERSION="${KIND_VERSION}" bash -c 'source hack/lib/install.sh; check-kind'
+
+# Install ctlptl if not present in _output/bin or wrong version
+dev-install-ctlptl:
+	@if [ ! -f ${CTLPTL_BIN} ] || [ "$$(${CTLPTL_BIN} version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "${CTLPTL_VERSION}" ]; then \
+		mkdir -p ${BIN_DIR}; \
+		curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v${CTLPTL_VERSION}/ctlptl.${CTLPTL_VERSION}.linux.${HOSTARCH}.tar.gz | tar -xz -C ${BIN_DIR} ctlptl; \
+		chmod +x ${CTLPTL_BIN}; \
+		printf "ctlptl installed at ${CTLPTL_BIN} (version ${CTLPTL_VERSION}).\n"; \
+	else \
+		printf "ctlptl already installed at ${CTLPTL_BIN} (version ${CTLPTL_VERSION}).\n"; \
+	fi
+
+# Create Kind cluster and registry for local dev via ctlptl.
+# Composes the ctlptl config with the shared kind cluster config at apply time
+# so that e2e-kind-config.yaml remains the single source of truth.
+dev-create-kind-cluster:
+	@{ \
+	  cat ${CTLPTL_CONFIG}; \
+	  printf 'kindV1Alpha4Cluster:\n'; \
+	  printf '  name: %s\n' '${KIND_CLUSTER_NAME}'; \
+	  sed -e '/^kind:/d' -e '/^apiVersion:/d' -e '/^[[:space:]]*$$/d' -e '/^#/d' -e 's/^/  /' ${KIND_CONFIG}; \
+	} | ${CTLPTL_BIN} apply -f -
+
+.PHONY: dev-up
+dev-up: dev-install-tilt dev-install-kind dev-install-ctlptl
+	$(MAKE) dev-create-kind-cluster
+	$(TILT_BIN) up -f hack/tilt/Tiltfile
+
+.PHONY: dev-down
+dev-down:
+	@$(TILT_BIN) down -f hack/tilt/Tiltfile 2>/dev/null || true
+	@pkill -f '^${TILT_BIN} up -f hack/tilt/Tiltfile$$' || true
+
+# Delete Kind cluster and registry managed by ctlptl
+.PHONY: dev-delete-kind-cluster
+dev-delete-kind-cluster:
+	@${CTLPTL_BIN} delete -f ${CTLPTL_CONFIG} --cascade=true --ignore-not-found || true
+
+.PHONY: dev-clean
+dev-clean: dev-down dev-delete-kind-cluster
+	rm -f $(KIND_BIN) $(CTLPTL_BIN) $(TILT_BIN)
+
+.PHONY: dev-status
+dev-status:
+	${CTLPTL_BIN} get cluster
+	@echo ---
+	@kubectl cluster-info --context ${KIND_CONTEXT_NAME} 2>/dev/null || kubectl cluster-info --context kind-${KIND_CLUSTER_NAME} 2>/dev/null || echo "Cluster not running."
+
+# Install Tilt if not present in _output/bin or wrong version
+dev-install-tilt:
+	@if [ ! -f ${TILT_BIN} ] || [ "$$(${TILT_BIN} version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "${TILT_VERSION}" ]; then \
+		mkdir -p ${BIN_DIR}; \
+		TMP_DIR=$$(mktemp -d); \
+		curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.linux.${HOSTARCH}.tar.gz | tar -xz -C $$TMP_DIR && \
+		mv $$TMP_DIR/tilt ${TILT_BIN}; \
+		rm -rf $$TMP_DIR; \
+		chmod +x ${TILT_BIN}; \
+		printf "Tilt installed at ${TILT_BIN} (version ${TILT_VERSION}).\n"; \
+	else \
+		printf "Tilt already installed at ${TILT_BIN} (version ${TILT_VERSION}).\n"; \
+	fi
+
+.PHONY: dev-tilt-status
+dev-tilt-status: dev-install-tilt
+	${TILT_BIN} get uiresource
+
+.PHONY: dev-tilt-logs
+dev-tilt-logs: dev-install-tilt
+	@if [ -n "${RESOURCE}" ]; then \
+		${TILT_BIN} logs ${RESOURCE}; \
+	else \
+		${TILT_BIN} logs; \
+	fi
+
+.PHONY: dev-tilt-describe
+dev-tilt-describe: dev-install-tilt
+	@if [ -z "${RESOURCE}" ]; then \
+		echo "RESOURCE is required. Example: make dev-tilt-describe RESOURCE=volcano-scheduler"; \
+		exit 1; \
+	fi
+	${TILT_BIN} describe uiresource ${RESOURCE}
+
+.PHONY: dev-tilt-trigger
+dev-tilt-trigger: dev-install-tilt
+	@if [ -z "${RESOURCE}" ]; then \
+		echo "RESOURCE is required. Example: make dev-tilt-trigger RESOURCE=volcano-scheduler"; \
+		exit 1; \
+	fi
+	${TILT_BIN} trigger ${RESOURCE}
+
+.PHONY: dev-wait-ready
+dev-wait-ready: dev-install-tilt
+	${TILT_BIN} wait --for=condition=Ready ${TILT_WAIT_RESOURCES} --timeout=${TILT_WAIT_TIMEOUT}

--- a/hack/tilt/Tiltfile
+++ b/hack/tilt/Tiltfile
@@ -1,0 +1,319 @@
+# Tiltfile for Volcano
+
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ensure Kind cluster exists for local dev
+kind_cluster_name = 'kind-volcano-dev'
+kind_k8s_context = kind_cluster_name
+allow_k8s_contexts([kind_k8s_context])
+e2e_local_cluster_env = 'CLUSTER_NAME=${CLUSTER_NAME:-' + kind_cluster_name + '} '
+
+# Set the default namespace for all resources
+k8s_namespace('volcano-system')
+
+# Apply namespace manifest
+root_dir = '../../'
+k8s_yaml(root_dir + 'installer/namespace.yaml')
+
+# Helm-based installation (using helm() pattern)
+volcano_yaml = helm(
+    root_dir + 'installer/helm/chart/volcano',
+    name='volcano',
+    namespace='volcano-system',
+    values=[root_dir + 'installer/helm/chart/volcano/values.yaml', 'values-tilt-override.yaml'],
+    set=[
+        'basic.admission_init_image_name=volcanosh/vc-admission-init',
+    ]
+)
+k8s_yaml(volcano_yaml)
+
+k8s_yaml(root_dir + 'installer/volcano-monitoring.yaml')
+
+# Build all images for local registry
+images = [
+    ('volcanosh/vc-scheduler', root_dir, 'scheduler'),
+    ('volcanosh/vc-controller-manager', root_dir, 'controller-manager'),
+    ('volcanosh/vc-webhook-manager', root_dir, 'webhook-manager'),
+]
+for name, path, component in images:
+    docker_build(
+        name,
+        path,
+        build_args=dict(COMPONENT=component),
+        dockerfile='Dockerfile.tilt',
+        only=['pkg/', 'third_party/', 'cmd/'+ component + '/', 'staging/', 'hack/tilt/entrypoint.sh', 'go.mod', 'go.sum'],
+        live_update=[
+            sync(root_dir + 'pkg', '/go/src/volcano.sh/volcano/pkg'),
+            sync(root_dir + 'third_party', '/go/src/volcano.sh/volcano/third_party'),
+            sync(root_dir + 'cmd/' + component, '/go/src/volcano.sh/volcano/cmd/' + component),
+            sync(root_dir + 'hack/tilt/entrypoint.sh', '/go/src/volcano.sh/volcano/entrypoint.sh'),
+            run('touch /tmp/reload')
+        ]
+    )
+
+docker_build(
+    'volcanosh/vc-admission-init',
+    root_dir,
+    dockerfile='Dockerfile.admission-init.tilt',
+    only=["installer/dockerfile/webhook-manager/gen-admission-secret.sh"],
+)
+
+
+# Group all namespaces
+k8s_resource(
+    new_name='volcano-namespaces',
+    objects=[
+        'volcano-system:namespace',
+        'volcano-monitoring:namespace',
+    ],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    new_name='volcano-crds',
+    objects=[
+        'jobtemplates.flow.volcano.sh:customresourcedefinition',
+        'jobflows.flow.volcano.sh:customresourcedefinition',
+        'jobs.batch.volcano.sh:customresourcedefinition',
+        'commands.bus.volcano.sh:customresourcedefinition',
+        'numatopologies.nodeinfo.volcano.sh:customresourcedefinition',
+        'podgroups.scheduling.volcano.sh:customresourcedefinition',
+        'queues.scheduling.volcano.sh:customresourcedefinition',
+        'hypernodes.topology.volcano.sh:customresourcedefinition',
+        'cronjobs.batch.volcano.sh:customresourcedefinition',
+        'nodeshards.shard.volcano.sh:customresourcedefinition',
+        'colocationconfigurations.config.volcano.sh:customresourcedefinition'
+    ],
+    labels=["volcano"]
+)
+
+
+# Group all admission-related resources
+k8s_resource(
+    'volcano-admission',
+    objects=[
+        'volcano-admission:serviceaccount',
+        'volcano-admission:clusterrole',
+        'volcano-admission-role:clusterrolebinding',
+        'volcano-admission-configmap:configmap',
+        'volcano-admission-service-queues-mutate:mutatingwebhookconfiguration',
+        'volcano-admission-service-jobs-mutate:mutatingwebhookconfiguration',
+        'volcano-admission-service-jobs-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-queues-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-podgroups-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-hypernodes-validate:validatingwebhookconfiguration',
+        'volcano-admission-service-cronjobs-validate:validatingwebhookconfiguration'
+    ],
+    resource_deps=['volcano-namespaces', 'volcano-crds', 'volcano-admission-init'],
+    labels=["volcano"]
+)
+
+# Group scheduler resources
+k8s_resource(
+    'volcano-scheduler',
+    objects=[
+        'volcano-scheduler:serviceaccount',
+        'volcano-scheduler:clusterrole',
+        'volcano-scheduler-role:clusterrolebinding',
+        'volcano-scheduler-configmap:configmap',
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["volcano"]
+)
+
+# Group controller resources
+k8s_resource(
+    'volcano-controllers',
+    objects=[
+        'volcano-controllers:serviceaccount',
+        'volcano-controllers:clusterrole',
+        'volcano-controllers-role:clusterrolebinding',
+        'volcano-controller-configmap:configmap'
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    new_name='volcano-vcjob-roles',
+    objects=[
+        'vcjob-editor-role:clusterrole',
+        'vcjob-viewer-role:clusterrole'
+    ],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    'volcano-admission-init',
+    extra_pod_selectors=[{'job-name': 'volcano-admission-init'}],
+    objects=[
+        'volcano-admission-init:serviceaccount',
+        'volcano-admission-init:role',
+        'volcano-admission-init-role:rolebinding',
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["volcano"]
+)
+
+k8s_resource(
+    'prometheus-deployment',
+    objects=[
+        'prometheus-volcano:clusterrolebinding',
+        'prometheus-volcano:clusterrole',
+        'prometheus-server-conf:configmap'
+    ],
+    resource_deps=['volcano-namespaces'],
+    port_forwards=3001,
+    labels=["monitoring"]    
+)
+
+k8s_resource(
+    'kube-state-metrics',
+    objects=[
+        'kube-state-metrics:serviceaccount',
+        'kube-state-metrics:clusterrole',
+        'kube-state-metrics:clusterrolebinding',
+    ],
+    resource_deps=['volcano-namespaces'],
+    labels=["monitoring"]
+)
+
+k8s_resource(
+    'grafana',
+    objects=[
+        'grafana-datasources:configmap',
+        'grafana-volcano-dashboard-config:configmap',
+        'grafana-volcano-dashboard:configmap',
+    ],
+    resource_deps=['volcano-namespaces'],
+    port_forwards=3000,
+    labels=["monitoring"]
+)
+
+local_resource(
+    'install-kwok',
+    'bash -c "source ' + root_dir + 'hack/lib/install.sh && install-kwok-with-helm"',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests-install"]
+)
+
+local_resource(
+    'install-ginkgo',
+    'bash -c "source ' + root_dir + 'hack/lib/install.sh && install-ginkgo-if-not-exist"',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests-install"]
+)
+
+# Optionally, run e2e tests (using local_resource)
+local_resource(
+    'unit-tests',
+    'make unit-test',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"]
+)
+
+local_resource(
+    'e2e-tests-all',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=ALL KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-kwok', 'install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-jobp',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=JOBP KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-jobseq',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=JOBSEQ KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-schedulingbase',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=SCHEDULINGBASE KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-schedulingaction',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=SCHEDULINGACTION KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-vcctl',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=VCCTL KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-dra',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=DRA KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-hypernode',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=HYPERNODE KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+local_resource(
+    'e2e-tests-cronjob',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=CRONJOB KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)
+
+# Focused example (single-test run)
+local_resource(
+    'e2e-tests-schedulingbase-focused-example',
+    e2e_local_cluster_env + 'E2E_LOCAL_ONLY=1 E2E_TYPE=SCHEDULINGBASE E2E_FOCUS="${E2E_FOCUS:-Gang scheduling}" E2E_SKIP="${E2E_SKIP:-\\[sig-.*\\]|Full Occupied}" KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config} ' + root_dir + 'hack/run-e2e-kind.sh',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=["tests"],
+    resource_deps=['install-ginkgo']
+)

--- a/hack/tilt/ctlptl-kind-registry.yaml
+++ b/hack/tilt/ctlptl-kind-registry.yaml
@@ -1,0 +1,10 @@
+apiVersion: ctlptl.dev/v1alpha1
+kind: Registry
+name: volcano-registry
+port: 5005
+---
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: kind-volcano-dev
+product: kind
+registry: volcano-registry

--- a/hack/tilt/entrypoint.sh
+++ b/hack/tilt/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright 2025 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SRC_DIR=/go/src/volcano.sh/volcano
+BIN="${SRC_DIR}/vc-${COMPONENT}"
+RELOAD_FILE="/tmp/reload"
+
+child_pid=0
+
+start_child() {
+  "$BIN" "$@" &
+  child_pid=$!
+}
+
+stop_child() {
+  if [ $child_pid -ne 0 ]; then
+    kill $child_pid
+    wait $child_pid 2>/dev/null || true
+  fi
+}
+
+start_child "$@"
+
+while true; do
+  if [ -f "$RELOAD_FILE" ]; then
+    echo "[entrypoint] Detected reload trigger, rebuilding and restarting..."
+    stop_child
+    GOOS=linux GOARCH="$(go env GOARCH)" go build -o "$BIN" ./cmd/${COMPONENT}
+    start_child "$@"
+    rm -f "$RELOAD_FILE"
+  fi
+  sleep 1
+done

--- a/hack/tilt/values-tilt-override.yaml
+++ b/hack/tilt/values-tilt-override.yaml
@@ -1,0 +1,33 @@
+basic:
+  image_pull_policy: IfNotPresent
+  scheduler_config_file: config/volcano-scheduler-ci.conf
+
+custom:
+  controller_log_level: 5
+  scheduler_log_level: 5
+  scheduler_schedule_period: 1s
+  admission_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  controller_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  scheduler_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  default_ns:
+    node-role.kubernetes.io/control-plane: ""
+  # scheduler_feature_gates: ${FEATURE_GATES}
+  # ignored_provisioners: ${IGNORED_PROVISIONERS:-""}

--- a/installer/helm/chart/volcano/templates/admission-init.yaml
+++ b/installer/helm/chart/volcano/templates/admission-init.yaml
@@ -107,8 +107,7 @@ spec:
           resources:
           {{- toYaml .Values.custom.admission_resources | nindent 12 }}
           {{- end }}
-          image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_image_name}}:{{ .Values.basic.admission_image_tag_version | default .Values.basic.image_tag_version }}
-          imagePullPolicy: {{ .Values.basic.image_pull_policy }}
+          image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_init_image_name}}:{{ .Values.basic.image_tag_version }}          imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           command: ["./gen-admission-secret.sh", "--service", "{{ .Release.Name }}-admission-service", "--namespace",
                     "{{ .Release.Namespace }}", "--secret", "{{.Values.basic.admission_secret_name}}"]
           {{- if $admission_init_csc }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -3,6 +3,7 @@ basic:
   scheduler_image_name: "volcanosh/vc-scheduler"
   agent_scheduler_image_name: "volcanosh/vc-agent-scheduler"
   admission_image_name: "volcanosh/vc-webhook-manager"
+  admission_init_image_name: "volcanosh/vc-webhook-manager"
   agent_image_name: "volcanosh/vc-agent"
   admission_secret_name: "volcano-admission-secret"
   admission_config_file: "config/volcano-admission.conf"


### PR DESCRIPTION
## Summary

- Adds a design proposal document for a Tilt-based local development workflow using Kind and ctlptl
- Implements the full workflow: Tiltfile, Dockerfiles, Makefile targets, Helm overrides, and live-reload entrypoint
- Updates developer documentation with quick-start instructions and operational tips

Resolves #6

## Design

See `docs/design/tilt-based-development.md` for the full proposal covering motivation, architecture, file layout, image building strategy, live-reload mechanism, and comparison with alternative tools (Skaffold, DevSpace, manual scripts).

## What's Included

### Commit 1: `docs: add Tilt-based local development design proposal`
- Design document at `docs/design/tilt-based-development.md`
- Developer guide updates in `docs/development/development.md` (Tilt workflow section with tips)
- Prerequisites update in `docs/development/prepare-for-development.md`

### Commit 2: `tilt: add Kind-based local dev workflow with live-reload`
- `hack/tilt/Tiltfile` — Tilt orchestration for 4 images + Helm deploy + resource grouping
- `hack/tilt/Dockerfile.tilt` — Multi-component Dockerfile with Go build + live-update support
- `hack/tilt/Dockerfile.admission-init.tilt` — Lightweight admission init image
- `hack/tilt/Makefile` — `dev-up`, `dev-down`, `dev-clean` targets with tool auto-install
- `hack/tilt/entrypoint.sh` — File-watch loop for in-container rebuild on sync
- `hack/tilt/ctlptl-kind-registry.yaml` — Declarative Kind + registry cluster config
- `hack/tilt/values-tilt-override.yaml` — Dev-specific Helm value overrides
- Root `Makefile` integration and `hack/lib/install.sh` version-aware Kind installer

## Quick Start

```bash
make dev-up    # Provisions cluster + starts Tilt (first run ~20-25 min)
make dev-down  # Stops Tilt, keeps cluster for fast restart
make dev-clean # Full teardown (cluster + registry)
```