### PR TITLE
fix(scheduler): prevent preemptorTasks overwrite in multi-queue preemption

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -227,25 +227,25 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 
 		// Preemption between Task within Job.
 		for _, job := range underRequest {
-			// Fix: preemptor numbers lose when in same job
-			preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
+			// Here we need to use a scoped intraJob priority queue instead of overwriting preemptorTasks[job.UID].
+			// The original preemptorTasks map is populated during job discovery (lines above)
+			// and consumed by the "Preemption between Jobs within Queue" loop.
+			// Overwriting it here causes preemptors from other queues' starving jobs to be
+			// lost due to non-deterministic Go map iteration order in multi-queue scenarios.
+			intraJobPreemptors := util.NewPriorityQueue(ssn.TaskOrderFn)
 			for _, task := range job.TaskStatusIndex[api.Pending] {
 				// Again, skip scheduling gated tasks
 				if task.SchGated {
 					continue
 				}
-				preemptorTasks[job.UID].Push(task)
+				intraJobPreemptors.Push(task)
 			}
 			for {
-				if _, found := preemptorTasks[job.UID]; !found {
+				if intraJobPreemptors.Empty() {
 					break
 				}
 
-				if preemptorTasks[job.UID].Empty() {
-					break
-				}
-
-				preemptor := preemptorTasks[job.UID].Pop().(*api.TaskInfo)
+				preemptor := intraJobPreemptors.Pop().(*api.TaskInfo)
 
 				stmt := framework.NewStatement(ssn)
 				assigned, err := pmpt.preempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -330,6 +330,50 @@ func TestPreempt(t *testing.T) {
 			ExpectEvictNum: 1,
 			ExpectEvicted:  []string{"c1/preemptee2"},
 		},
+		{
+			// Regression test for the preemptorTasks overwrite issue in multi-queue preemption.
+			//
+			// Instead of:
+			//    intraJobPreemptors := util.NewPriorityQueue(ssn.TaskOrderFn)
+			// We have used:
+			//    preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
+			// in the "Preemption between Task within Job" loop, which caused preemptorTasks to be overwritten/drained across queues.
+			// This test verifies that the preemptorTasks for pg3 (high-priority preemptor in q2) is not overwritten/drained when processing q1, so that pg3 can successfully preempt pg2.
+			//
+			// Scenario:
+			// - q1 has a running non-starving job (pg1) and no preemptor.
+			// - q2 has a low-priority running victim (pg2) and a high-priority starving
+			//   preemptor job (pg3).
+			// - underRequest is shared across queues.
+			//
+			// Buggy behavior:
+			// - While processing q1, the intra-job pass overwrites/drains
+			//   preemptorTasks[pg3], so q2 later sees no preemptor and skips eviction.
+			//
+			// Why this was flaky:
+			// - Queue iteration order came from a Go map, so the run usually passed when
+			//   q2 was visited first, but failed when q1 was visited first.
+			Name: "multi-queue: preemptorTasks must not be overwritten by intra-job preemption of another queue",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroup("pg1", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+				util.BuildPodGroupWithPrio("pg3", "c1", "q2", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "q1-runner1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "q2-preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg2", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "q2-preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg3", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+				util.BuildQueue("q2", 1, api.BuildResourceList("4", "4G")),
+			},
+			ExpectEvicted:  []string{"c1/q2-preemptee1"},
+			ExpectEvictNum: 1,
+		},
 	}
 
 	trueValue := true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a multi-queue preemption bug where `preemptorTasks[job.UID]` was overwritten during intra-job preemption. In multi-queue scenarios, this could clear preemptors discovered for another queue and cause missed evictions depending on queue iteration order.

The fix uses a scoped `intraJobPreemptors` queue for the intra-job pass, so the shared between-job preemptor state is preserved.

#### Which issue(s) this PR fixes:

N/A (bug ticket draft prepared separately)

#### Special notes for your reviewer:

- Includes a dedicated regression test in `TestPreempt` for the multi-queue overwrite scenario.
- Flakiness verification from local stress runs:
  - without fix: 21 passes / 9 fails (30 runs)
  - with fix: 30 passes / 0 fails (30 runs)

#### Does this PR introduce a user-facing change?

```release-note
Fix a scheduler preemption bug in multi-queue scenarios where pending preemptors could be lost and valid evictions skipped due to intra-job preemptor queue overwrite.
```